### PR TITLE
Ignore unsupported algorithms in NHS ID jwk keys

### DIFF
--- a/gateway/backends.py
+++ b/gateway/backends.py
@@ -1,7 +1,13 @@
+import logging
 from urllib.parse import urljoin
 
 from django.conf import settings
+from jose import jwk
+from jose.exceptions import JWKError
+from jose.utils import base64url_decode
 from social_core.backends.open_id_connect import OpenIdConnectAuth
+
+logger = logging.getLogger(__name__)
 
 
 class NHSIDConnectAuth(OpenIdConnectAuth):
@@ -40,3 +46,31 @@ class NHSIDConnectAuth(OpenIdConnectAuth):
         # NHS organisation details (from the associatedorgs scope)
         values["nhsid_user_orgs"] = response.get("nhsid_user_orgs", [])
         return values
+
+    def find_valid_key(self, id_token):
+        try:
+            return super().find_valid_key(id_token)
+        except JWKError:
+            for key in self.get_jwks_keys():
+                # Here we go through all the keys retrieved from the jwks endpoint one
+                # by one until we find one that can be verified.
+                # NHS Identity's OIDC provider's jwks endpoint returns keys for
+                # algorithms that jose doesn't currently support
+                # However, NHS Identity always uses RS256 to sign JWTs unless
+                # specifically requested to do otherwise, so we can just ignore key
+                # construction failures.
+                # Log the unsupported key as a warning in case we ever attempt to use an
+                # unsupported algorithm in future.
+                # The key construction is not wrapped in a try...except so that other,
+                # legitimate errors will still be raised.
+                if jwk.get_key(key["alg"]) is not None:
+                    rsakey = jwk.construct(key)
+                    message, encoded_sig = id_token.rsplit(".", 1)
+                    decoded_sig = base64url_decode(encoded_sig.encode("utf-8"))
+                    if rsakey.verify(message.encode("utf-8"), decoded_sig):
+                        logger.info("Key verified with algorithm %s.", key["alg"])
+                        return key
+                else:
+                    logger.warning(
+                        "Algorithm %s is not currently supported.", key["alg"]
+                    )

--- a/tests/test_nhsid_auth.py
+++ b/tests/test_nhsid_auth.py
@@ -32,6 +32,7 @@ class AuthTestOptions:
     backend: NHSIDConnectAuth
     strategy: DjangoStrategy
     user_data_body: Optional[dict] = None
+    jwk_keys: Optional[list] = None
     # The following are options for testing invalid tokens
     nonce: Optional[str] = None
     token_expiry_datetime: Optional[datetime] = None
@@ -68,12 +69,12 @@ def do_auth(httpretty, start_url, auth_options, access_token_body):
     httpretty.register_uri(httpretty.GET, start_url, status=301, location=target_url)
     httpretty.register_uri(httpretty.GET, target_url, status=200, body="foobar")
 
-    # Mock the JWKS token request (used to validate JWT id_token)
+    # Mock the JWK keys request (used to validate JWT id_token)
     httpretty.register_uri(
         httpretty.GET,
         auth_options.backend.jwks_uri(),
         status=200,
-        body=json.dumps({"keys": [JWK_PUBLIC_KEY]}),
+        body=json.dumps({"keys": auth_options.jwk_keys or [JWK_PUBLIC_KEY]}),
     )
     # Mock the call to get the access token
     httpretty.register_uri(
@@ -225,6 +226,47 @@ def test_nhsid_backend_complete(httpretty, mock_settings, mock_backend_and_strat
         "organisations": [],
     }
     assert_user_attributes(user, expected)
+
+
+@pytest.mark.django_db
+def test_unsupported_algorithm(httpretty, mock_settings, mock_backend_and_strategy):
+    assert User.objects.exists() is False
+    user_data_body = {"sub": 1, "name": "Test User", "nhsid_useruid": "test"}
+    backend, strategy = mock_backend_and_strategy
+    # Mock the keys returned from the JWKS uri to include an unsupported algorithm
+    # before the supported one; the unsupported algorithm will be tried first and
+    # should not raise an error
+    unsupported = dict(JWK_PUBLIC_KEY)
+    unsupported["alg"] = "UNK"
+    auth_options = AuthTestOptions(
+        backend=backend,
+        strategy=strategy,
+        user_data_body=user_data_body,
+        jwk_keys=[unsupported, JWK_PUBLIC_KEY],
+    )
+    user = do_login(httpretty, auth_options)
+    assert user.username == "test"
+
+
+@pytest.mark.django_db
+def test_no_supported_algorithms(httpretty, mock_settings, mock_backend_and_strategy):
+    assert User.objects.exists() is False
+    user_data_body = {"sub": 1, "name": "Test User", "nhsid_useruid": "test"}
+    backend, strategy = mock_backend_and_strategy
+    # Mock the keys returned from the JWKS uri so that no algorithms returned are
+    # supported
+    unsupported = dict(JWK_PUBLIC_KEY)
+    unsupported["alg"] = "UNK"
+    auth_options = AuthTestOptions(
+        backend=backend,
+        strategy=strategy,
+        user_data_body=user_data_body,
+        jwk_keys=[unsupported],
+    )
+    with pytest.raises(
+        AuthTokenError, match="Token error: Signature verification failed"
+    ):
+        do_login(httpretty, auth_options)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
NHS Identity did their regular key rollover last week, and login started to raise a jose (the library that python-social-auth uses for JWKs) error with the message `Unable to find an algorithm for key PS384`.  It turns out that jose doesn't support all the algorithms that are returned from the NHS Identity jwks_uri endpoint.  When the OpenID Connect backend attempts to find a valid key, it loops through all the keys returned from the jwks_uri endpoint, constructs a key from them, and attempts to verify it.  The first verified key is returned.

AFAICT, NHS Identity hasn't added new algorithms; I'm guessing that the order that they are returned in has changed, and the supported algorithm that we're using (RS256) was previously returned first (or at least, before any of the unsupported ones). 