### PR TITLE
Update production cache to use Memcached

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,20 @@ dokku$ chown dokku:dokku /var/lib/dokku/data/storage/output-explorer
 dokku$ dokku storage:mount output-explorer /var/lib/dokku/data/storage/output-explorer/:/storage
 ```
 
+
+### Set up Memcached
+```
+dokku$ dokku memcached:create oe-cache
+dokku$ dokku memcached:link oe-cache output-explorer
+```
+
 ### Configure app
 ```
 dokku$ dokku config:set output-explorer BASE_URL='https://output-explorer.opensafely.org'
 dokku$ dokku config:set output-explorer DATABASE_URL='sqlite:////storage/db.sqlite3'
 dokku$ dokku config:set output-explorer SECRET_KEY='xxx'
+dokku$ dokku config:set output-explorer CACHE_BACKEND='django.core.cache.backends.memcached.PyMemcacheCache'
+dokku$ dokku config:set output-explorer CACHE_LOCATION='dokku-memcached-oe-cache:11211'
 dokku$ dokku config:set output-explorer SENTRY_DSN='https://xxx@xxx.ingest.sentry.io/xxx'
 dokku$ dokku config:set output-explorer SENTRY_ENVIRONMENT='production'
 dokku$ dokku config:set output-explorer SOCIAL_AUTH_NHSID_KEY='xxx'

--- a/output_explorer/settings.py
+++ b/output_explorer/settings.py
@@ -99,6 +99,17 @@ WSGI_APPLICATION = "output_explorer.wsgi.application"
 
 DATABASES = {"default": env.dj_db_url("DATABASE_URL", "sqlite:///db.sqlite3")}
 
+# Cache
+CACHES = {
+    "default": {
+        "BACKEND": env.str(
+            "CACHE_BACKEND", "django.core.cache.backends.locmem.LocMemCache"
+        ),
+        "LOCATION": env.str("CACHE_LOCATION", "default"),
+    }
+}
+
+
 # Default primary key field type to use for models that don’t have a field with primary_key=True.
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 

--- a/requirements.in
+++ b/requirements.in
@@ -5,6 +5,7 @@ django-structlog
 furl
 gunicorn
 PyGithub
+pymemcache
 social-auth-core[openidconnect]
 social-auth-app-django
 sentry-sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -174,6 +174,10 @@ pyjwt==2.1.0 \
     # via
     #   pygithub
     #   social-auth-core
+pymemcache==3.4.2 \
+    --hash=sha256:62462d9c6887549d1bb9718c0384b445c3a1d1021ddf250ff17e2f603248585e \
+    --hash=sha256:ff6f7db6893e05e30b259b25ca399181d1d20eb6f78b8c999448be997f26745f
+    # via -r requirements.in
 pynacl==1.4.0 \
     --hash=sha256:06cbb4d9b2c4bd3c8dc0d267416aaed79906e7b33f114ddbf0911969794b1cc4 \
     --hash=sha256:11335f09060af52c97137d4ac54285bcb7df0cef29014a1a4efe64ac065434c4 \
@@ -236,6 +240,7 @@ six==1.16.0 \
     #   ecdsa
     #   furl
     #   orderedmultidict
+    #   pymemcache
     #   pynacl
     #   python-jose
     #   social-auth-app-django


### PR DESCRIPTION
Tested using local memcached and is working and caching fine (dokku plugin set up is done too)
This could be simplified by using django-cache-url, but it needs upgrading to support the `PyMemcacheCache` backend (there's a PR for it already, and I have a PR ready to go once there's a new release of django-cache-url)
