### PR TITLE
Strip default styling from output html content

### DIFF
--- a/outputs/github.py
+++ b/outputs/github.py
@@ -80,13 +80,11 @@ class GitHubOutput:
             self.output.save()
 
         soup = BeautifulSoup(contents, "html.parser")
-        style = soup.find_all("style")
         body = soup.find("body")
-        style = [mark_safe(style_item.decode()) for style_item in style]
         contents = "".join(
             [
                 content.decode() if isinstance(content, Tag) else content
                 for content in body.contents
             ]
         )
-        return {"body": mark_safe(contents), "style": style}
+        return {"body": mark_safe(contents)}

--- a/outputs/templates/outputs/output.html
+++ b/outputs/templates/outputs/output.html
@@ -3,9 +3,6 @@
 {% load static %}
 
 {% block extra_head %}
-    {% for style in notebook_style %}
-        {{ style }}
-    {% endfor %}
 {% endblock %}
 
 

--- a/outputs/views.py
+++ b/outputs/views.py
@@ -49,7 +49,6 @@ def output_fetch_view(request, github_output):
         request,
         "outputs/output.html",
         {
-            "notebook_style": extracted["style"],
             "notebook_contents": extracted["body"],
             "output": github_output.output,
         },

--- a/tests/outputs/test_github.py
+++ b/tests/outputs/test_github.py
@@ -31,10 +31,6 @@ def test_get_html_from_github(mock_repo):
     extracted_html = github_output.get_html()
     assert extracted_html == {
         "body": "<p>foo</p>",
-        "style": [
-            '<style type="text/css">body {margin: 0;}</style>',
-            '<style type="text/css">a {background-color: red;}</style>',
-        ],
     }
 
 
@@ -56,7 +52,7 @@ def test_get_large_html_from_github(mock_repo):
     github_output = GitHubOutput(output, repo=repo)
     extracted_html = github_output.get_html()
     output.refresh_from_db()
-    assert extracted_html == {"body": "<p>blob</p>", "style": []}
+    assert extracted_html == {"body": "<p>blob</p>"}
     assert output.last_updated == date(2021, 4, 27)
 
     # After the first get_html call, use_git_blob is set to avoid re-attempting to call
@@ -67,7 +63,7 @@ def test_get_large_html_from_github(mock_repo):
 
     # re-fetch; get_contents is not called again on the single file, only on the parent folder
     extracted_html = github_output.get_html()
-    assert extracted_html == {"body": "<p>blob</p>", "style": []}
+    assert extracted_html == {"body": "<p>blob</p>"}
     assert repo.get_contents.call_count == 3
 
 
@@ -85,8 +81,4 @@ def test_integration():
     extracted_html = github_output.get_html()
     assert extracted_html == {
         "body": "\n<h1>A Test Output HTML file</h1>\n<p>The test content\t\n</p>",
-        "style": [
-            '<style type="text/css">body {margin: 0;}</style>',
-            '<style type="text/css">a {background-color: blue;}</style>',
-        ],
     }

--- a/tests/outputs/test_views.py
+++ b/tests/outputs/test_views.py
@@ -44,10 +44,6 @@ def test_output_view(client):
     # output for a real file
     output = baker.make_recipe("outputs.real_output")
     response = client.get(output.get_absolute_url())
-    assert response.context["notebook_style"] == [
-        '<style type="text/css">body {margin: 0;}</style>',
-        '<style type="text/css">a {background-color: blue;}</style>',
-    ]
     assert (
         response.context["notebook_contents"]
         == "\n<h1>A Test Output HTML file</h1>\n<p>The test content\t\n</p>"


### PR DESCRIPTION
fixes #42 
Get rid of all the styling from an output html file (converted notebook retrieved from github) and only show the content of its <body> tag in the template. This is in preparation for applying our own custom styling.