### PR TITLE
Use artefacts for assets folder in GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,10 +51,10 @@ jobs:
       - name: Install node_modules
         run: npm install
 
-      - name: Build project
+      - name: Build assets
         run: npm run build
 
-      - name: Archive production artifacts
+      - name: Store assets
         uses: actions/upload-artifact@v2
         with:
           name: node-assets
@@ -145,15 +145,11 @@ jobs:
           path: ${{ github.workspace }}/venv
           key: venv-${{ github.ref }}-${{ hashFiles('requirements.txt', 'requirements.dev.txt') }}
 
-      - name: Use assets artifact
+      - name: Retrieve assets
         uses: actions/download-artifact@v2
         with:
           name: node-assets
           path: static/dist
-
-      - name: Display structure of downloaded files
-        run: ls -R
-        working-directory: static/dist
 
       - name: Check requirements
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,11 +54,11 @@ jobs:
       - name: Build project
         run: npm run build
 
-      - name: Cache the assets
-        uses: actions/cache@v2
+      - name: Archive production artifacts
+        uses: actions/upload-artifact@v2
         with:
-          path: ${{ github.workspace }}/static/dist
-          key: assets-${{ github.ref }}-${{ hashFiles('static/dist/manifest.json') }}
+          name: node-assets
+          path: static/dist
 
 
   format:
@@ -145,11 +145,15 @@ jobs:
           path: ${{ github.workspace }}/venv
           key: venv-${{ github.ref }}-${{ hashFiles('requirements.txt', 'requirements.dev.txt') }}
 
-      - name: Use the cached assets
-        uses: actions/cache@v2
+      - name: Use assets artifact
+        uses: actions/download-artifact@v2
         with:
-          path: ${{ github.workspace }}/static/dist
-          key: assets-${{ github.ref }}-${{ hashFiles('static/dist/manifest.json') }}
+          name: node-assets
+          path: static/dist
+
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: static/dist
 
       - name: Check requirements
         run: |


### PR DESCRIPTION
The generated assets were being cached using [`actions/cache@v2`](https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows). They should instead be [stored as an artefact](https://docs.github.com/en/actions/guides/storing-workflow-data-as-artifacts#passing-data-between-jobs-in-a-workflow) so that they can be passed between jobs.