### PR TITLE
GitHub refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 .coverage
 htmlcov/
 .DS_Store
-cache.sqlite
+http_cache.sqlite
 test_cache.sqlite
 db.sqlite3
 collected-static/

--- a/dotenv-sample
+++ b/dotenv-sample
@@ -16,5 +16,3 @@ SOCIAL_AUTH_NHSID_API_URL=https://am.nhsdev.auth-ptl.cis2.spineservices.nhs.uk/o
 
 # flag for showing/hiding login option
 SHOW_LOGIN=True
-
-REQUESTS_CACHE_NAME=cache

--- a/gateway/views.py
+++ b/gateway/views.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-import requests_cache
 import structlog
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.db.models import F, Value
@@ -59,16 +58,15 @@ def nhsid_complete(request, *args, **kwargs):
     A successful authentication from  NHS ID returns to /auth. social_django expects to
     find the backend name in the url (by default /complete/<backend>)
     """
-    with requests_cache.disabled():
-        backend = "nhsid"
-        uri = reverse("gateway:nhsid_complete")
-        request.social_strategy = load_strategy(request)
-        request.backend = load_backend(request.social_strategy, backend, uri)
-        completed = complete(request, backend, *args, **kwargs)
-        logger.info(
-            "User logged in", user_id=request.user.pk, username=request.user.username
-        )
-        return completed
+    backend = "nhsid"
+    uri = reverse("gateway:nhsid_complete")
+    request.social_strategy = load_strategy(request)
+    request.backend = load_backend(request.social_strategy, backend, uri)
+    completed = complete(request, backend, *args, **kwargs)
+    logger.info(
+        "User logged in", user_id=request.user.pk, username=request.user.username
+    )
+    return completed
 
 
 class OrganisationDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView):

--- a/outputs/apps.py
+++ b/outputs/apps.py
@@ -1,4 +1,3 @@
-import requests_cache
 from django.apps import AppConfig
 from environs import Env
 
@@ -9,6 +8,3 @@ env = Env()
 class OutputsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "outputs"
-
-
-requests_cache.install_cache(env.str("REQUESTS_CACHE_NAME"), backend="sqlite")

--- a/outputs/github.py
+++ b/outputs/github.py
@@ -2,19 +2,147 @@ from base64 import b64decode
 from datetime import datetime
 from pathlib import Path
 
+import requests
+import requests_cache
 from bs4 import BeautifulSoup, Tag
 from django.utils.safestring import mark_safe
 from environs import Env
-from github import Github, GithubException
+from furl import furl
 
 
 env = Env()
 
 
-class GitHubOutput:
-    def __init__(self, output, repo=None):
+class GithubAPIException(Exception):
+    ...
+
+
+class GithubClient:
+    """
+    A connection to the Github API, using cached requests by default
+    """
+
+    user_agent = "OpenSAFELY Output Explorer"
+    base_url = "https://api.github.com"
+
+    def __init__(self, use_cache=True):
         token = env.str("GITHUB_TOKEN", None)
-        self.client = Github(token) if token else Github()
+        self.headers = {
+            "Accept": "application/vnd.github.v3+json",
+            "User-Agent": self.user_agent,
+        }
+        if token:
+            self.headers["Authorization"] = f"token {env.str('GITHUB_TOKEN')}"
+        if use_cache:
+            self.session = requests_cache.CachedSession(
+                backend="sqlite", namespace=env.str("REQUESTS_CACHE_NAME", "http_cache")
+            )
+        else:
+            self.session = requests.Session()
+
+    def _get_json(self, path_segments, ref=None):
+        """
+        Builds and calls a url from the base and path segments
+        Returns the Last-Modified header and json response
+        """
+        f = furl(self.base_url)
+        f.path.segments += path_segments
+        if ref is not None:
+            f.add({"ref": ref})
+        response = self.session.get(f.url, headers=self.headers)
+
+        # Report some expected errors
+        if response.status_code == 403:
+            errors = response.json()["errors"]
+            for error in errors:
+                if error["code"] == "too_large":
+                    raise GithubAPIException("Error: File too large")
+        elif response.status_code == 404:
+            raise GithubAPIException(response.json()["message"])
+        # raise any other unexpected status
+        response.raise_for_status()
+        response_json = response.json()
+        last_modified = response.headers.get("Last-Modified")
+        return response_json, last_modified
+
+    def get_repo(self, owner_and_repo):
+        """
+        Ensure a repo exists and return a GithubRepo
+        """
+        owner, repo = owner_and_repo.split("/")
+        repo_path_seqments = ["repos", owner, repo]
+        # call it to raise exceptions in case it doesn't exist
+        self._get_json(repo_path_seqments)
+        return GithubRepo(self, owner, repo)
+
+
+class GithubRepo:
+    """
+    Fetch contents of a Github Repo
+    """
+
+    def __init__(self, client, owner, name):
+        self.client = client
+        self.repo_path_segments = ["repos", owner, name]
+
+    def get_contents(self, path, ref):
+        """
+        Fetch the contents of a path and ref (branch/commit/tag)
+
+        Returns a single GithubContentFile if the path is a single file, or a list
+        of GithubContentFiles if the path is a folder
+        """
+        path_segments = [*self.repo_path_segments, "contents", path]
+        contents, last_modified = self.client._get_json(path_segments, ref)
+        if isinstance(contents, list):
+            return [
+                GithubContentFile.from_json({**content, "last_modified": last_modified})
+                for content in contents
+            ]
+        contents["last_modified"] = last_modified
+        return GithubContentFile.from_json(contents)
+
+    def get_git_blob(self, sha, last_modified):
+        """Fetch a git blob by sha"""
+        path_segments = [*self.repo_path_segments, "git", "blobs", sha]
+        response, _ = self.client._get_json(path_segments)
+        response["last_modified"] = last_modified
+        return GithubContentFile.from_json(response)
+
+
+class GithubContentFile:
+    """Holds information about a single file in a repo"""
+
+    def __init__(self, name, last_modified, content, sha):
+        self.name = name
+        self.last_modified = last_modified
+        self.content = content
+        self.sha = sha
+
+    @classmethod
+    def from_json(cls, json_input):
+        return cls(
+            name=json_input.get("name"),
+            content=json_input.get("content"),
+            last_modified=json_input.get("last_modified"),
+            sha=json_input["sha"],
+        )
+
+    @property
+    def decoded_content(self):
+        # self.content may be None when /contents has returned a list of files
+        if self.content:
+            return b64decode(self.content).decode("utf-8")
+
+
+class GitHubOutput:
+    """
+    A class for interacting with a Github repo and html file associated with a single
+    Output instance
+    """
+
+    def __init__(self, output, repo=None, use_cache=True):
+        self.client = GithubClient(use_cache=use_cache)
         self.output = output
         self._repo = repo
 
@@ -39,15 +167,14 @@ class GitHubOutput:
     def get_contents_from_git_blob(self):
         """
         Get all the content files from the parent folder (doesn't download the actual content
-        itself, but returns a list of ContentFile objects, from which we can obtain sha for
-        the relevant file, retrieve the git blob and return the html contents
+        itself, but returns a list of GithubContentFile objects, from which we can obtain sha for
+        the relevant file), retrieve the git blob and return it as a GithubContentFile
         """
         # Find the file in the parent folder whose name matches the output file we want
         matching_content_file = next(self.matching_output_file_from_parent_contents())
         last_updated = matching_content_file.last_modified
-        blob = self.repo.get_git_blob(matching_content_file.sha)
-        contents = b64decode(blob.content)
-        return contents, last_updated
+        blob = self.repo.get_git_blob(matching_content_file.sha, last_updated)
+        return blob
 
     def get_html(self):
         """
@@ -57,21 +184,22 @@ class GitHubOutput:
         Return the style tags and html body content for display in template.
         """
         if self.output.use_git_blob:
-            contents, last_updated = self.get_contents_from_git_blob()
+            contents = self.get_contents_from_git_blob()
         else:
             try:
                 contents = self.repo.get_contents(
                     self.output.output_html_file_path, ref=self.output.branch
                 )
-                last_updated = contents.last_modified
-                contents = contents.decoded_content
 
-            except GithubException:
+            except GithubAPIException:
                 # If the single file was too big (>1Mb), we get an exception.  Get the git blob
                 # and retrieve the contents from there instead
-                contents, last_updated = self.get_contents_from_git_blob()
+                contents = self.get_contents_from_git_blob()
                 self.output.use_git_blob = True
                 self.output.save()
+
+        last_updated = contents.last_modified
+        contents = contents.decoded_content
         last_updated_date = datetime.strptime(
             last_updated, "%a, %d %b %Y %H:%M:%S %Z"
         ).date()

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -2,6 +2,7 @@
 black
 flake8
 httpretty
+ipdb
 isort
 model-bakery
 pre-commit

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -10,6 +10,10 @@ appdirs==1.4.4 \
     # via
     #   black
     #   virtualenv
+appnope==0.1.2 \
+    --hash=sha256:93aa393e9d6c54c5cd570ccadd8edad61ea0c4b9ea7a01409020c9aa019eb442 \
+    --hash=sha256:dd83cd4b5b460958838f6eb3000c660b1f9caf2a5b1de4264e941512f603258a
+    # via ipython
 asgiref==3.3.4 \
     --hash=sha256:92906c611ce6c967347bbfea733f13d6313901d54dcca88195eaeb52b2a8e8ee \
     --hash=sha256:d1216dfbdfb63826470995d31caed36225dcaf34f182e0fa257a4dd9e86f1b78
@@ -20,6 +24,10 @@ attrs==21.2.0 \
     --hash=sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1 \
     --hash=sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb
     # via pytest
+backcall==0.2.0 \
+    --hash=sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e \
+    --hash=sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255
+    # via ipython
 black==21.5b1 \
     --hash=sha256:23695358dbcb3deafe7f0a3ad89feee5999a46be5fec21f4f1d108be0bcdb3b1 \
     --hash=sha256:8a60071a0043876a4ae96e6c69bd3a127dad2c1ca7c8083573eb82f92705d008
@@ -86,6 +94,10 @@ coverage[toml]==5.5 \
     --hash=sha256:f0b278ce10936db1a37e6954e15a3730bea96a0997c26d7fee88e6c396c2086d \
     --hash=sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6
     # via pytest-cov
+decorator==5.0.9 \
+    --hash=sha256:6e5c199c16f7a9f0e3a61a4a54b3d27e7dad0dbdde92b944426cb20914376323 \
+    --hash=sha256:72ecfba4320a893c53f9706bebb2d55c270c1e51a28789361aa93e4a21319ed5
+    # via ipython
 distlib==0.3.1 \
     --hash=sha256:8c09de2c67b3e7deef7184574fc060ab8a793e7adbb183d942c389c8b13c52fb \
     --hash=sha256:edf6116872c863e1aa9d5bb7cb5e05a022c519a4594dc703843343a9ddd9bff1
@@ -115,10 +127,29 @@ iniconfig==1.1.1 \
     --hash=sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3 \
     --hash=sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32
     # via pytest
+ipdb==0.13.7 \
+    --hash=sha256:178c367a61c1039e44e17c56fcc4a6e7dc11b33561261382d419b6ddb4401810
+    # via -r requirements.dev.in
+ipython-genutils==0.2.0 \
+    --hash=sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8 \
+    --hash=sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8
+    # via traitlets
+ipython==7.23.1 \
+    --hash=sha256:714810a5c74f512b69d5f3b944c86e592cee0a5fb9c728e582f074610f6cf038 \
+    --hash=sha256:f78c6a3972dde1cc9e4041cbf4de583546314ba52d3c97208e5b6b2221a9cb7d
+    # via ipdb
 isort==5.8.0 \
     --hash=sha256:0a943902919f65c5684ac4e0154b1ad4fac6dcaa5d9f3426b732f1c8b5419be6 \
     --hash=sha256:2bb1680aad211e3c9944dbce1d4ba09a989f04e238296c87fe2139faa26d655d
     # via -r requirements.dev.in
+jedi==0.18.0 \
+    --hash=sha256:18456d83f65f400ab0c2d3319e48520420ef43b23a086fdc05dff34132f0fb93 \
+    --hash=sha256:92550a404bad8afed881a137ec9a461fed49eca661414be45059329614ed0707
+    # via ipython
+matplotlib-inline==0.1.2 \
+    --hash=sha256:5cf1176f554abb4fa98cb362aa2b55c500147e4bdbb07e3fda359143e1da0811 \
+    --hash=sha256:f41d5ff73c9f5385775d5c0bc13b424535c8402fe70ea8210f93e11f3683993e
+    # via ipython
 mccabe==0.6.1 \
     --hash=sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42 \
     --hash=sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f
@@ -139,10 +170,22 @@ packaging==20.9 \
     --hash=sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5 \
     --hash=sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a
     # via pytest
+parso==0.8.2 \
+    --hash=sha256:12b83492c6239ce32ff5eed6d3639d6a536170723c6f3f1506869f1ace413398 \
+    --hash=sha256:a8c4922db71e4fdb90e0d0bc6e50f9b273d3397925e5e60a717e719201778d22
+    # via jedi
 pathspec==0.8.1 \
     --hash=sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd \
     --hash=sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d
     # via black
+pexpect==4.8.0 \
+    --hash=sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937 \
+    --hash=sha256:fc65a43959d153d0114afe13997d439c22823a27cefceb5ff35c2178c6784c0c
+    # via ipython
+pickleshare==0.7.5 \
+    --hash=sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca \
+    --hash=sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56
+    # via ipython
 pluggy==0.13.1 \
     --hash=sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0 \
     --hash=sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d
@@ -151,6 +194,14 @@ pre-commit==2.12.1 \
     --hash=sha256:70c5ec1f30406250b706eda35e868b87e3e4ba099af8787e3e8b4b01e84f4712 \
     --hash=sha256:900d3c7e1bf4cf0374bb2893c24c23304952181405b4d88c9c40b72bda1bb8a9
     # via -r requirements.dev.in
+prompt-toolkit==3.0.18 \
+    --hash=sha256:bf00f22079f5fadc949f42ae8ff7f05702826a97059ffcc6281036ad40ac6f04 \
+    --hash=sha256:e1b4f11b9336a28fa11810bc623c357420f69dfdb6d2dac41ca2c21a55c033bc
+    # via ipython
+ptyprocess==0.7.0 \
+    --hash=sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35 \
+    --hash=sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220
+    # via pexpect
 py==1.10.0 \
     --hash=sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3 \
     --hash=sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a
@@ -163,6 +214,10 @@ pyflakes==2.3.1 \
     --hash=sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3 \
     --hash=sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db
     # via flake8
+pygments==2.9.0 \
+    --hash=sha256:a18f47b506a429f6f4b9df81bb02beab9ca21d0a5fee38ed15aef65f0545519f \
+    --hash=sha256:d66e804411278594d764fc69ec36ec13d9ae9147193a1740cd34d272ca383b8e
+    # via ipython
 pyparsing==2.4.7 \
     --hash=sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1 \
     --hash=sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b
@@ -288,9 +343,24 @@ toml==0.10.2 \
     # via
     #   black
     #   coverage
+    #   ipdb
     #   pre-commit
     #   pytest
+traitlets==5.0.5 \
+    --hash=sha256:178f4ce988f69189f7e523337a3e11d91c786ded9360174a3d9ca83e79bc5396 \
+    --hash=sha256:69ff3f9d5351f31a7ad80443c2674b7099df13cc41fc5fa6e2f6d3b0330b0426
+    # via
+    #   ipython
+    #   matplotlib-inline
 virtualenv==20.4.6 \
     --hash=sha256:307a555cf21e1550885c82120eccaf5acedf42978fd362d32ba8410f9593f543 \
     --hash=sha256:72cf267afc04bf9c86ec932329b7e94db6a0331ae9847576daaa7ca3c86b29a4
     # via pre-commit
+wcwidth==0.2.5 \
+    --hash=sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784 \
+    --hash=sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83
+    # via prompt-toolkit
+
+# WARNING: The following packages were not pinned, but pip requires them to be
+# pinned when the requirements file includes hashes. Consider using the --allow-unsafe flag.
+# setuptools

--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,6 @@ django-structlog
 django-vite
 furl
 gunicorn
-PyGithub
 django-redis
 requests-cache
 social-auth-core[openidconnect]

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,14 +58,23 @@ certifi==2020.12.5 \
     #   sentry-sdk
 cffi==1.14.5 \
     --hash=sha256:005a36f41773e148deac64b08f233873a4d0c18b053d37da83f6af4d9087b813 \
+    --hash=sha256:04c468b622ed31d408fea2346bec5bbffba2cc44226302a0de1ade9f5ea3d373 \
+    --hash=sha256:06d7cd1abac2ffd92e65c0609661866709b4b2d82dd15f611e602b9b188b0b69 \
+    --hash=sha256:06db6321b7a68b2bd6df96d08a5adadc1fa0e8f419226e25b2a5fbf6ccc7350f \
     --hash=sha256:0857f0ae312d855239a55c81ef453ee8fd24136eaba8e87a2eceba644c0d4c06 \
+    --hash=sha256:0f861a89e0043afec2a51fd177a567005847973be86f709bbb044d7f42fc4e05 \
     --hash=sha256:1071534bbbf8cbb31b498d5d9db0f274f2f7a865adca4ae429e147ba40f73dea \
     --hash=sha256:158d0d15119b4b7ff6b926536763dc0714313aa59e320ddf787502c70c4d4bee \
+    --hash=sha256:1bf1ac1984eaa7675ca8d5745a8cb87ef7abecb5592178406e55858d411eadc0 \
     --hash=sha256:1f436816fc868b098b0d63b8920de7d208c90a67212546d02f84fe78a9c26396 \
+    --hash=sha256:24a570cd11895b60829e941f2613a4f79df1a27344cbbb82164ef2e0116f09c7 \
+    --hash=sha256:24ec4ff2c5c0c8f9c6b87d5bb53555bf267e1e6f70e52e5a9740d32861d36b6f \
     --hash=sha256:2894f2df484ff56d717bead0a5c2abb6b9d2bf26d6960c4604d5c48bbc30ee73 \
     --hash=sha256:29314480e958fd8aab22e4a58b355b629c59bf5f2ac2492b61e3dc06d8c7a315 \
+    --hash=sha256:293e7ea41280cb28c6fcaaa0b1aa1f533b8ce060b9e701d78511e1e6c4a1de76 \
     --hash=sha256:34eff4b97f3d982fb93e2831e6750127d1355a923ebaeeb565407b3d2f8d41a1 \
     --hash=sha256:35f27e6eb43380fa080dccf676dece30bef72e4a67617ffda586641cd4508d49 \
+    --hash=sha256:3c3f39fa737542161d8b0d680df2ec249334cd70a8f420f71c9304bd83c3cbed \
     --hash=sha256:3d3dd4c9e559eb172ecf00a2a7517e97d1e96de2a5e610bd9b68cea3925b4892 \
     --hash=sha256:43e0b9d9e2c9e5d152946b9c5fe062c151614b262fda2e7b201204de0b99e482 \
     --hash=sha256:48e1c69bbacfc3d932221851b39d49e81567a4d4aac3b21258d9c24578280058 \
@@ -73,6 +82,7 @@ cffi==1.14.5 \
     --hash=sha256:58e3f59d583d413809d60779492342801d6e82fefb89c86a38e040c16883be53 \
     --hash=sha256:5de7970188bb46b7bf9858eb6890aad302577a5f6f75091fd7cdd3ef13ef3045 \
     --hash=sha256:65fa59693c62cf06e45ddbb822165394a288edce9e276647f0046e1ec26920f3 \
+    --hash=sha256:681d07b0d1e3c462dd15585ef5e33cb021321588bebd910124ef4f4fb71aef55 \
     --hash=sha256:69e395c24fc60aad6bb4fa7e583698ea6cc684648e1ffb7fe85e3c1ca131a7d5 \
     --hash=sha256:6c97d7350133666fbb5cf4abdc1178c812cb205dc6f41d174a7b0f18fb93337e \
     --hash=sha256:6e4714cc64f474e4d6e37cfff31a814b509a35cb17de4fb1999907575684479c \
@@ -90,13 +100,13 @@ cffi==1.14.5 \
     --hash=sha256:b85eb46a81787c50650f2392b9b4ef23e1f126313b9e0e9013b35c15e4288e2e \
     --hash=sha256:bb89f306e5da99f4d922728ddcd6f7fcebb3241fc40edebcb7284d7514741991 \
     --hash=sha256:cbde590d4faaa07c72bf979734738f328d239913ba3e043b1e98fe9a39f8b2b6 \
+    --hash=sha256:cc5a8e069b9ebfa22e26d0e6b97d6f9781302fe7f4f2b8776c3e1daea35f1adc \
     --hash=sha256:cd2868886d547469123fadc46eac7ea5253ea7fcb139f12e1dfc2bbd406427d1 \
     --hash=sha256:d42b11d692e11b6634f7613ad8df5d6d5f8875f5d48939520d351007b3c13406 \
+    --hash=sha256:df5052c5d867c1ea0b311fb7c3cd28b19df469c056f7fdcfe88c7473aa63e333 \
     --hash=sha256:f2d45f97ab6bb54753eab54fffe75aaf3de4ff2341c9daee1987ee1837636f1d \
     --hash=sha256:fd78e5fee591709f32ef6edb9a015b4aa1a5022598e36227500c8f4e02328d9c
-    # via
-    #   cryptography
-    #   pynacl
+    # via cryptography
 chardet==4.0.0 \
     --hash=sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa \
     --hash=sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5
@@ -121,10 +131,6 @@ defusedxml==0.7.1 \
     # via
     #   python3-openid
     #   social-auth-core
-deprecated==1.2.12 \
-    --hash=sha256:08452d69b6b5bc66e8330adde0a4f8642e969b9e1702904d137eeb29c8ffc771 \
-    --hash=sha256:6d2de2de7931a968874481ef30208fd4e08da39177d61d3d4ebdf4366e7dbca1
-    # via pygithub
 dj-database-url==0.5.0 \
     --hash=sha256:4aeaeb1f573c74835b0686a2b46b85990571159ffc21aa57ecd4d1e1cb334163 \
     --hash=sha256:851785365761ebe4994a921b433062309eb882fedd318e1b0fcecc607ed02da9
@@ -212,36 +218,10 @@ pycparser==2.20 \
     --hash=sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0 \
     --hash=sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705
     # via cffi
-pygithub==1.55 \
-    --hash=sha256:1bbfff9372047ff3f21d5cd8e07720f3dbfdaf6462fcaed9d815f528f1ba7283 \
-    --hash=sha256:2caf0054ea079b71e539741ae56c5a95e073b81fa472ce222e81667381b9601b
-    # via -r requirements.in
 pyjwt==2.1.0 \
     --hash=sha256:934d73fbba91b0483d3857d1aff50e96b2a892384ee2c17417ed3203f173fca1 \
     --hash=sha256:fba44e7898bbca160a2b2b501f492824fc8382485d3a6f11ba5d0c1937ce6130
-    # via
-    #   pygithub
-    #   social-auth-core
-pynacl==1.4.0 \
-    --hash=sha256:06cbb4d9b2c4bd3c8dc0d267416aaed79906e7b33f114ddbf0911969794b1cc4 \
-    --hash=sha256:11335f09060af52c97137d4ac54285bcb7df0cef29014a1a4efe64ac065434c4 \
-    --hash=sha256:2fe0fc5a2480361dcaf4e6e7cea00e078fcda07ba45f811b167e3f99e8cff574 \
-    --hash=sha256:30f9b96db44e09b3304f9ea95079b1b7316b2b4f3744fe3aaecccd95d547063d \
-    --hash=sha256:4e10569f8cbed81cb7526ae137049759d2a8d57726d52c1a000a3ce366779634 \
-    --hash=sha256:511d269ee845037b95c9781aa702f90ccc36036f95d0f31373a6a79bd8242e25 \
-    --hash=sha256:537a7ccbea22905a0ab36ea58577b39d1fa9b1884869d173b5cf111f006f689f \
-    --hash=sha256:54e9a2c849c742006516ad56a88f5c74bf2ce92c9f67435187c3c5953b346505 \
-    --hash=sha256:757250ddb3bff1eecd7e41e65f7f833a8405fede0194319f87899690624f2122 \
-    --hash=sha256:7757ae33dae81c300487591c68790dfb5145c7d03324000433d9a2c141f82af7 \
-    --hash=sha256:7c6092102219f59ff29788860ccb021e80fffd953920c4a8653889c029b2d420 \
-    --hash=sha256:8122ba5f2a2169ca5da936b2e5a511740ffb73979381b4229d9188f6dcb22f1f \
-    --hash=sha256:9c4a7ea4fb81536c1b1f5cc44d54a296f96ae78c1ebd2311bd0b60be45a48d96 \
-    --hash=sha256:c914f78da4953b33d4685e3cdc7ce63401247a21425c16a39760e282075ac4a6 \
-    --hash=sha256:cd401ccbc2a249a47a3a1724c2918fcd04be1f7b54eb2a5a71ff915db0ac51c6 \
-    --hash=sha256:d452a6746f0a7e11121e64625109bc4468fc3100452817001dbe018bb8b08514 \
-    --hash=sha256:ea6841bc3a76fa4942ce00f3bda7d436fda21e2d91602b9e21b7ca9ecab8f3ff \
-    --hash=sha256:f8851ab9041756003119368c1e6cd0b9c631f46d686b3904b18c0139f4419f80
-    # via pygithub
+    # via social-auth-core
 python-dotenv==0.17.1 \
     --hash=sha256:00aa34e92d992e9f8383730816359647f358f4a3be1ba45e5a5cefd27ee91544 \
     --hash=sha256:b1ae5e9643d5ed987fc57cc2583021e38db531946518130777734f9589b3141f
@@ -274,7 +254,6 @@ requests==2.25.1 \
     --hash=sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804 \
     --hash=sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e
     # via
-    #   pygithub
     #   requests-cache
     #   requests-oauthlib
     #   social-auth-core
@@ -293,7 +272,6 @@ six==1.16.0 \
     #   ecdsa
     #   furl
     #   orderedmultidict
-    #   pynacl
     #   python-jose
     #   social-auth-app-django
     #   url-normalize
@@ -334,9 +312,6 @@ whitenoise[brotli]==5.2.0 \
     --hash=sha256:05ce0be39ad85740a78750c86a93485c40f08ad8c62a6006de0233765996e5c7 \
     --hash=sha256:05d00198c777028d72d8b0bbd234db605ef6d60e9410125124002518a48e515d
     # via -r requirements.in
-wrapt==1.12.1 \
-    --hash=sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7
-    # via deprecated
 
 # WARNING: The following packages were not pinned, but pip requires them to be
 # pinned when the requirements file includes hashes. Consider using the --allow-unsafe flag.

--- a/tests/outputs/test_github.py
+++ b/tests/outputs/test_github.py
@@ -1,11 +1,227 @@
+import json
 from base64 import b64encode
 from datetime import date
+from os import environ
 
 import pytest
 from model_bakery import baker
+from requests.exceptions import HTTPError
 
-from outputs.github import GithubAPIException, GitHubOutput
+from outputs.github import GithubAPIException, GithubClient, GitHubOutput, GithubRepo
 from outputs.models import Output
+
+
+def test_github_client_get_repo(httpretty):
+    # Mock the github request
+    httpretty.register_uri(
+        httpretty.GET,
+        "https://api.github.com/repos/test/foo",
+        status=200,
+        body=json.dumps({"name": "foo"}),
+    )
+    client = GithubClient()
+    repo = client.get_repo("test/foo")
+    assert repo.repo_path_segments == ["repos", "test", "foo"]
+
+
+def test_github_client_token(reset_environment_after_test):
+    """Authorization headers is set based on environment variable"""
+    environ["GITHUB_TOKEN"] = "test"
+    client = GithubClient()
+    assert client.headers["Authorization"] == "token test"
+
+    del environ["GITHUB_TOKEN"]
+    client = GithubClient()
+    assert "Authorization" not in client.headers
+
+
+def test_github_client_get_repo_not_found(httpretty):
+    # Mock the github request
+    httpretty.register_uri(
+        httpretty.GET,
+        "https://api.github.com/repos/test/bar",
+        status=404,
+        body=json.dumps({"message": "Not found"}),
+    )
+    client = GithubClient()
+    with pytest.raises(GithubAPIException, match="Not found"):
+        client.get_repo("test/bar")
+
+
+@pytest.mark.parametrize("use_cache", [True, False])
+def test_github_client_get_repo_with_cache(httpretty, use_cache):
+    client = GithubClient(use_cache=use_cache)
+
+    # set up mock request with valid response and call it
+    httpretty.register_uri(
+        httpretty.GET,
+        "https://api.github.com/repos/test/test-cache",
+        status=200,
+        body=json.dumps({"name": "foo"}),
+    )
+    client.get_repo("test/test-cache")
+
+    # re-mock the repos request to a 404, should raise an exception if called directly
+    httpretty.register_uri(
+        httpretty.GET,
+        "https://api.github.com/repos/test/test-cache",
+        status=404,
+        body=json.dumps({"message": "Not found"}),
+    )
+    if use_cache:
+        # No exception raised because the first response was cached
+        client.get_repo("test/test-cache")
+    else:
+        # Exception raised because the repos endpoint was fetched again
+        with pytest.raises(GithubAPIException, match="Not found"):
+            client.get_repo("test/test-cache")
+
+
+def test_github_repo_get_contents_single_file(httpretty):
+    repo = GithubRepo(client=GithubClient(use_cache=False), owner="test", name="foo")
+    str_content = """
+        <html>
+            <head>
+                <style type="text/css">body {margin: 0;}</style>
+                <style type="text/css">a {background-color: red;}</style>
+                <script src="https://a-js-package.js"></script>
+            </head>
+            <body><p>foo</p></body>
+        </html>
+    """
+    # Content retrieved from GitHub is base64-encoded, decoded to str for json
+    b64_content = b64encode(bytes(str_content, encoding="utf-8")).decode()
+    # Mock the github request
+    httpretty.register_uri(
+        httpretty.GET,
+        "https://api.github.com/repos/test/foo/contents/test-folder%2Ftest-file.html?ref=master",
+        status=200,
+        body=json.dumps(
+            {
+                "name": "test-file.html",
+                "path": "test-folder/test-file.html",
+                "sha": "abcd1234",
+                "size": 1234,
+                "encoding": "base64",
+                "content": b64_content,
+            }
+        ),
+    )
+    content_file = repo.get_contents("test-folder/test-file.html", ref="master")
+    assert content_file.name == "test-file.html"
+    # decoded content retrieves the original str contents
+    assert content_file.decoded_content == str_content
+
+
+@pytest.mark.parametrize(
+    "status_code,body,expected_exception,expected_match",
+    [
+        (
+            403,
+            {"errors": [{"code": "too_large", "message": "File was too large"}]},
+            GithubAPIException,
+            "Error: File too large",
+        ),
+        (404, {"message": "Not found"}, GithubAPIException, "Not found"),
+        (
+            403,
+            {"errors": [{"code": "other_code", "message": "An unexpected 403"}]},
+            HTTPError,
+            "Forbidden for url",
+        ),
+        (
+            401,
+            {"errors": [{"code": "other_code", "message": "An unexpected 403"}]},
+            HTTPError,
+            "Unauthorized for url",
+        ),
+    ],
+)
+def test_github_repo_get_contents_exceptions(
+    httpretty, status_code, body, expected_exception, expected_match
+):
+    """
+    Test expected and unexpected exceptions from get_contents
+    """
+    repo = GithubRepo(client=GithubClient(use_cache=False), owner="test", name="foo")
+    # Mock the github request
+    httpretty.register_uri(
+        httpretty.GET,
+        "https://api.github.com/repos/test/foo/contents/test-folder%2Ftest-file.html?ref=master",
+        status=status_code,
+        body=json.dumps(body),
+    )
+    with pytest.raises(expected_exception, match=expected_match):
+        repo.get_contents("test-folder/test-file.html", ref="master")
+
+
+def test_github_repo_get_contents_folder(httpretty):
+    repo = GithubRepo(client=GithubClient(use_cache=False), owner="test", name="foo")
+    # Mock the github request
+    httpretty.register_uri(
+        httpretty.GET,
+        "https://api.github.com/repos/test/foo/contents/test-folder?ref=master",
+        status=200,
+        body=json.dumps(
+            [
+                {
+                    "name": "test-file1.html",
+                    "path": "test-folder/test-file1.html",
+                    "sha": "abcd1234",
+                    "size": 1234,
+                    "encoding": "base64",
+                },
+                {
+                    "name": "test-file2.html",
+                    "path": "test-folder/test-file2.html",
+                    "sha": "abcd5678",
+                    "size": 1234,
+                    "encoding": "base64",
+                },
+            ]
+        ),
+    )
+    contents = repo.get_contents("test-folder", ref="master")
+    assert isinstance(contents, list)
+    assert len(contents) == 2
+    assert contents[0].name == "test-file1.html"
+    assert contents[1].name == "test-file2.html"
+
+
+def test_github_repo_get_git_blob(httpretty):
+    repo = GithubRepo(client=GithubClient(use_cache=False), owner="test", name="foo")
+    str_content = """
+        <html>
+            <head>
+                <style type="text/css">body {margin: 0;}</style>
+                <style type="text/css">a {background-color: red;}</style>
+                <script src="https://a-js-package.js"></script>
+            </head>
+            <body><p>foo</p></body>
+        </html>
+    """
+    # Content retrieved from GitHub is base64-encoded, decoded to str for json
+    b64_content = b64encode(bytes(str_content, encoding="utf-8")).decode()
+    # Mock the github request
+    httpretty.register_uri(
+        httpretty.GET,
+        "https://api.github.com/repos/test/foo/git/blobs/abcd1234",
+        status=200,
+        body=json.dumps(
+            {
+                "name": "test-file.html",
+                "path": "test-folder/test-file.html",
+                "sha": "abcd1234",
+                "size": 1234,
+                "encoding": "base64",
+                "content": b64_content,
+            }
+        ),
+    )
+    content_file = repo.get_git_blob("abcd1234", None)
+    assert content_file.name == "test-file.html"
+    # decoded content retrieves the original str contents
+    assert content_file.decoded_content == str_content
 
 
 @pytest.mark.django_db
@@ -23,19 +239,19 @@ from outputs.models import Output
             <body><p>foo</p></body>
         </html>
         """
-        ),
+        ).decode(),
         b64encode(
             b"""
         <html>
             <body><p>foo</p></body>
         </html>
         """
-        ),
+        ).decode(),
         b64encode(
             b"""
         <p>foo</p>
         """
-        ),
+        ).decode(),
         b64encode(
             b"""
         <body>
@@ -44,7 +260,7 @@ from outputs.models import Output
             <script>Some more Javascript nonsense</script>
         </body>
         """
-        ),
+        ).decode(),
         b64encode(
             b"""
         <body>
@@ -53,7 +269,7 @@ from outputs.models import Output
             <style>MOAR STYLZ</style>
         </body>
         """
-        ),
+        ).decode(),
     ],
     ids=[
         "Extracts body from HTML full document",
@@ -63,12 +279,26 @@ from outputs.models import Output
         "Strips out all style tags",
     ],
 )
-def test_get_output_from_github(mock_repo, retrieved_html):
+def test_get_output_from_github(httpretty, retrieved_html):
     """
     Test that html content retrieved from github is appropriately parsed
     """
-    repo = mock_repo(contents=retrieved_html)
+    repo = GithubRepo(GithubClient(use_cache=False), name="test", owner="test")
     output = baker.make(Output, output_html_file_path="foo.html")
+    # Mock the github request
+    httpretty.register_uri(
+        httpretty.GET,
+        "https://api.github.com/repos/test/test/contents/foo.html?ref=main",
+        responses=[
+            httpretty.Response(
+                status=200,
+                body=json.dumps(
+                    {"name": "foo.html", "sha": "abcd1234", "content": retrieved_html}
+                ),
+                adding_headers={"Last-Modified": "Tue, 27 Apr 2021 10:00:00 GMT"},
+            )
+        ],
+    )
     github_output = GitHubOutput(output, repo=repo)
     extracted_html = github_output.get_html()
     assert extracted_html == {
@@ -77,19 +307,52 @@ def test_get_output_from_github(mock_repo, retrieved_html):
 
 
 @pytest.mark.django_db
-def test_get_large_html_from_github(mock_repo):
+def test_get_large_html_from_github(httpretty):
     """
     Test that a GithubException for a too-large file is caught and the content fetched
     from the git_blob by sha instead
     """
-    repo = mock_repo(
-        content_files=["bar.html", "foo.html"],
-        blob=b64encode(b"<html><body><p>blob</p></body></html>"),
-        get_contents_exception=GithubAPIException("Error: File too large"),
+    # Mock the github requests
+    # /contents on the too-large file returns a 403
+    httpretty.register_uri(
+        httpretty.GET,
+        "https://api.github.com/repos/test/test/contents/foo.html?ref=main",
+        status=403,
+        body=json.dumps({"errors": [{"code": "too_large"}]}),
     )
+    # /contents on the parent folder returns two files
+    httpretty.register_uri(
+        httpretty.GET,
+        "https://api.github.com/repos/test/test/contents/?ref=main",
+        status=200,
+        body=json.dumps(
+            [
+                {"name": "bar.html", "sha": "abcd9999"},
+                {"name": "foo.html", "sha": "abcd1234"},
+            ]
+        ),
+        adding_headers={"Last-Modified": "Tue, 27 Apr 2021 10:00:00 GMT"},
+    )
+    # /git/blobs on the sha from the found file in the parent folder
+    httpretty.register_uri(
+        httpretty.GET,
+        "https://api.github.com/repos/test/test/git/blobs/abcd1234",
+        status=200,
+        body=json.dumps(
+            {
+                "name": "foo.html",
+                "path": "foo.html",
+                "sha": "abcd1234",
+                "size": 1234,
+                "encoding": "base64",
+                "content": b64encode(b"<html><body><p>blob</p></body></html>").decode(),
+            }
+        ),
+    )
+
+    repo = GithubRepo(client=GithubClient(use_cache=False), owner="test", name="test")
     output = baker.make(Output, output_html_file_path="foo.html")
     assert output.use_git_blob is False
-    assert repo.get_contents.call_count == 0
 
     github_output = GitHubOutput(output, repo=repo)
     extracted_html = github_output.get_html()
@@ -97,16 +360,48 @@ def test_get_large_html_from_github(mock_repo):
     assert extracted_html == {"body": "<p>blob</p>"}
     assert output.last_updated == date(2021, 4, 27)
 
+    # 3 calls were made, to /contents for the single file, then to /contents for the
+    # parent folder, and /git/blob for the file contents
+    assert len(httpretty.latest_requests()) == 3
+
     # After the first get_html call, use_git_blob is set to avoid re-attempting to call
     # get_contents on the single file, which will fail
     # get_contents is called twice, once on the single file, once for the parent folder contents
-    assert repo.get_contents.call_count == 2
     assert output.use_git_blob is True
 
-    # re-fetch; get_contents is not called again on the single file, only on the parent folder
+    # # re-fetch; get_contents is not called again on the single file, only on the parent folder
     extracted_html = github_output.get_html()
     assert extracted_html == {"body": "<p>blob</p>"}
-    assert repo.get_contents.call_count == 3
+    # Only 2 more calls, to /contents for the parent folder, and /git/blob for the file contents
+    latest_requests = httpretty.latest_requests()
+    assert len(latest_requests) == 5
+    assert (
+        latest_requests[-2].url
+        == "https://api.github.com/repos/test/test/contents/?ref=main"
+    )
+    assert (
+        latest_requests[-1].url
+        == "https://api.github.com/repos/test/test/git/blobs/abcd1234"
+    )
+
+
+@pytest.mark.django_db
+def test_github_output_get_parent_contents_invalid_folder(httpretty):
+    repo = GithubRepo(
+        client=GithubClient(use_cache=False), owner="test", name="test-folder"
+    )
+    output = baker.make(Output, output_html_file_path="test-folder/foo.html")
+
+    # Mock the github request
+    httpretty.register_uri(
+        httpretty.GET,
+        "https://api.github.com/repos/test/test-folder/contents/test-folder?ref=main",
+        status=404,
+        body=json.dumps({"message": "Not found"}),
+    )
+    github_output = GitHubOutput(output, repo=repo)
+    with pytest.raises(GithubAPIException, match="Not found"):
+        github_output.get_parent_contents()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Refactors the Github API calls so that `requests_cache` is used more explicitly only for GitHub, and we don't need to monkeypatch requests everywhere (and remember to disable it in other places, e.g. the NHS ID auth).  This meant getting rid of PyGithub, since I couldn't find a way to patch requests in just the calls being made through PyGithub.

Also refactored the tests to use httpretty and mock the specific github calls rather than the convoluted nest of PyGithub mocks that we had before.