### PR TITLE
Redirect bad cache tokens to latest report

### DIFF
--- a/reports/urls.py
+++ b/reports/urls.py
@@ -7,6 +7,8 @@ from .views import report_view
 app_name = "reports"
 
 urlpatterns = [
-    path("<slug:slug>/<uuid:cache_token>", report_view, name="report_view"),
+    path("<slug:slug>/<uuid:cache_token>/", report_view, name="report_view"),
+    path("<slug:slug>/<str:cache_token>/", report_view, name="report_view"),
+    path("<slug:slug>/", report_view, name="report_view"),
     path("", RedirectView.as_view(url="/", permanent=True)),
 ]

--- a/reports/views.py
+++ b/reports/views.py
@@ -13,7 +13,7 @@ logger = structlog.getLogger()
 
 
 @cache_control(cache_timeout=86400)
-def report_view(request, slug, cache_token):
+def report_view(request, slug, cache_token=None):
     """
     Fetches an html report file from github, and renders the style and body tags within
     the report template page.  Caches for 24 hours, can be forced to refetch and update

--- a/tests/reports/test_views.py
+++ b/tests/reports/test_views.py
@@ -113,14 +113,17 @@ def test_report_view(client):
 
 
 @pytest.mark.django_db
-def test_report_view_with_invalid_token(client):
+@pytest.mark.parametrize(
+    "cache_token",
+    [uuid4(), "a-non-token-string", None],
+    ids=["Test invalid uuid", "Test invalid string", "Test no token"],
+)
+def test_report_view_with_invalid_token(client, cache_token):
     """Test a single report page"""
     # report for a real file
     report = baker.make_recipe("reports.real_report")
-    invalid_uuid = uuid4()
-    response = client.get(
-        reverse("reports:report_view", args=(report.slug, invalid_uuid))
-    )
+    args = (report.slug, cache_token) if cache_token is not None else (report.slug,)
+    response = client.get(reverse("reports:report_view", args=args))
     assert response.status_code == 302
     assert response.url == report.get_absolute_url()
 


### PR DESCRIPTION
fixes #88 
We already redirected invalid cache tokens to the latest report if they were valid uuids.  This adds additional redirects for strings that aren't uuids, and for a report url with no cache token