### PR TITLE
Set the meta_title and meta_description variables in templates

### DIFF
--- a/gateway/templates/gateway/landing.html
+++ b/gateway/templates/gateway/landing.html
@@ -1,13 +1,13 @@
 {% extends 'base.html' %}
 {% load static %}
 
-{% block meta_title %}
-  OpenSAFELY Reports: Home
-{% endblock meta_title %}
-
-{% block meta_description %}
-  Regularly updated reports related to the COVID-19 pandemic, curated by the DataLab at the University of Oxford, working on behalf of NHS England.
-{% endblock meta_description %}
+  {% block meta %}
+    {% with meta_title="OpenSAFELY Reports: Home" meta_description="Regularly updated reports related to the COVID-19 pandemic, curated by the DataLab at the University of Oxford, working on behalf of NHS England." %}
+      <title>{{ meta_title }}</title>
+      <meta name="description" content="{{ meta_description }}">
+      {% include "partials/seo.html" %}
+    {% endwith %}
+  {% endblock %}
 
 {% block content %}
   <div class="bg-blue-50 mb-4 lg:mb-8">

--- a/reports/models.py
+++ b/reports/models.py
@@ -104,6 +104,10 @@ class Report(models.Model):
         self.cache_token = uuid4()
         self.save()
 
+    @property
+    def meta_title(self):
+        return f"{self.title} | OpenSAFELY: Reports"
+
     def clean(self):
         """Validate the repo, branch and report file path on save"""
         # Disable caching to fetch the repo and contents.  If this is a new report file in

--- a/reports/templates/reports/report.html
+++ b/reports/templates/reports/report.html
@@ -5,15 +5,15 @@
 
 {% block extra_head %}
   {% vite_asset 'assets/scripts/notebook.js' %}
+{% endblock %}}
+
+{% block meta %}
+  {% with meta_title=report.meta_title meta_description=report.description %}
+    <title>{{ meta_title }}</title>
+    <meta name="description" content="{{ meta_description }}">
+    {% include "partials/seo.html" %}
+  {% endwith %}
 {% endblock %}
-
-{% block meta_title %}
-  {{ report.title }} | OpenSAFELY: Reports
-{% endblock meta_title %}
-
-{% block meta_description %}
-  {{ report.description }}
-{% endblock meta_description %}
 
 {% block content %}
 <div class="container mx-auto px-4 md:px-8">

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,9 +8,13 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
 
-  <title>{% block meta_title %}OpenSAFELY: Reports{% endblock meta_title %}</title>
-  <meta name="description" content="{% block meta_description %}Reports related to the COVID-19 pandemic, curated by the DataLab at the University of Oxford, working on behalf of NHS England.{% endblock %}">
-  {% include "partials/seo.html" %}
+  {% block meta %}
+    {% with meta_title="OpenSAFELY: Reports" meta_description="Reports related to the COVID-19 pandemic, curated by the DataLab at the University of Oxford, working on behalf of NHS England." %}
+      <title>{{ meta_title }}</title>
+      <meta name="description" content="{{ meta_description }}">
+      {% include "partials/seo.html" %}
+    {% endwith %}
+  {% endblock %}
 
   {% vite_hmr_client %}
   {% vite_asset 'assets/scripts/main.js' %}


### PR DESCRIPTION
Slightly different to what I suggested before, but this is working for me locally and avoids repeating the title/description (need to add the `?force-update=` query param to pick it up in the report pages)