### PR TITLE
Make a researchers group with permissions

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 ./manage.py migrate
+./manage.py ensure_groups
 ./manage.py collectstatic --no-input
 
 exec "$@"

--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@ dev-config:
 	./scripts/dev-env.sh .env
 
 # set up/update the local dev env
-setup: pip-install npm-install migrate ensure-superuser ensure-reports collectstatic
+setup: pip-install npm-install migrate ensure-superuser ensure-reports ensure-groups collectstatic
 
 # install correct versions of all Python dependencies
 pip-install:
@@ -52,6 +52,10 @@ ensure-superuser:
 # ensure the local app is populated with example reports
 ensure-reports:
     INCLUDE_PRIVATE=t ./manage.py populate_reports
+
+# ensure the researchers group exists with relevant permissions
+ensure-groups:
+    ./manage.py ensure_groups
 
 # blow away the local database and repopulate it
 dev-reset:

--- a/reports/management/commands/ensure_groups.py
+++ b/reports/management/commands/ensure_groups.py
@@ -1,0 +1,17 @@
+from django.contrib.auth.models import Group, Permission
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = "Ensure the researchers group exists with relevant permissions."
+
+    def handle(self, *args, **options):
+        group, _ = Group.objects.get_or_create(name="researchers")
+        models = ["report", "category"]
+        required_permissions = Permission.objects.filter(
+            content_type__app_label="reports", content_type__model__in=models
+        )
+        group_permissions = group.permissions.all()
+        missing_permissions = set(required_permissions) - set(group_permissions)
+        for missing_permission in missing_permissions:
+            group.permissions.add(missing_permission)

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -14,7 +14,6 @@
     </div>
 
     <div class="ml-4 flex items-center lg:ml-6">
-      {% if show_login %}
         {% if user.is_authenticated %}
           <div class="relative inline-block text-left" x-data="{ open: false }">
             <div>
@@ -49,6 +48,13 @@
                   {{ request.user.username }}
                 </p>
               </div>
+              {% if request.user.is_staff %}
+                <div class="py-1">
+                  <a href="{% url 'admin:index' %}" class="text-gray-700 block w-full text-left px-4 py-2 text-sm hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-700" role="menuitem" >
+                    Admin
+                  </a>
+                </div>
+              {% endif %}
               <div class="py-1">
                 <a href="{% url 'gateway:logout' %}" class="text-gray-700 block w-full text-left px-4 py-2 text-sm hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-700" role="menuitem" >
                   Sign out
@@ -57,11 +63,12 @@
             </div>
           </div>
         {% else %}
-          <a href="{% url 'gateway:login' %}" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-700">
-            Login
-          </a>
+          {% if show_login %}
+            <a href="{% url 'gateway:login' %}" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-700">
+              Login
+            </a>
+          {% endif %}
         {% endif %}
-      {% endif %}
     </div>
   </div>
 </div>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,8 +8,9 @@ import httpretty as _httpretty
 import pytest
 import structlog
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Permission
+from django.contrib.auth.models import Group, Permission
 from django.contrib.sessions.middleware import SessionMiddleware
+from django.core import management
 from django.test import RequestFactory
 from model_bakery import baker
 from social_django.utils import load_strategy
@@ -34,6 +35,15 @@ def user_with_permission():
 @pytest.fixture
 def user_no_permission():
     yield User.objects.create_user(username="user2", password="testpass")
+
+
+@pytest.fixture
+def researcher():
+    management.call_command("ensure_groups")
+    group = Group.objects.get(name="researchers")
+    user = User.objects.create_user(username="researcher", password="testpass")
+    user.groups.add(group)
+    yield user
 
 
 def _remove_cache_file_if_exists():

--- a/tests/reports/test_views.py
+++ b/tests/reports/test_views.py
@@ -231,12 +231,15 @@ def test_report_view(client):
         ("no_permission", True, 404),
         ("has_permission", False, 200),
         ("has_permission", True, 200),
+        ("researcher", False, 200),
+        ("researcher", True, 200),
     ],
 )
 def test_draft_report_view_permissions(
     client,
     user_no_permission,
     user_with_permission,
+    researcher,
     user_attributes,
     is_draft,
     expected_status,
@@ -247,6 +250,7 @@ def test_draft_report_view_permissions(
     user_selection = {
         "no_permission": user_no_permission,
         "has_permission": user_with_permission,
+        "researcher": researcher,
     }
     user = user_selection.get(user_attributes)
     if user is not None:


### PR DESCRIPTION
Management command to create a "researchers" group which gives members access to the `reports` app models only.  This includes the `view_draft` permission, so any user in the researchers group automatically has permission to view drafts.

Also added an admin link for logged in staff users in the template

The idea is that for now we will create staff user accounts for Datalab researchers so they can log into the django admin but can only see/add/edit Reports and Categories.  

Fixes #104 