### PR TITLE
Clear requests cache as well as http cache when refreshing a Report cache token

### DIFF
--- a/reports/github.py
+++ b/reports/github.py
@@ -214,3 +214,11 @@ class GithubReport:
             self.report.save()
 
         return file.decoded_content
+
+    def clear_cache(self):
+        """Clear all request cache urls for this repo"""
+        cached_urls = self.client.session.cache.urls
+        repo_path = f"opensafely/{self.report.repo}".lower()
+        for cached_url in cached_urls:
+            if repo_path in cached_url.lower():
+                self.client.session.cache.delete_url(cached_url)

--- a/reports/github.py
+++ b/reports/github.py
@@ -33,7 +33,8 @@ class GithubClient:
             self.headers["Authorization"] = f"token {env.str('GITHUB_TOKEN')}"
         if use_cache:
             self.session = requests_cache.CachedSession(
-                backend="sqlite", namespace=env.str("REQUESTS_CACHE_NAME", "http_cache")
+                backend="sqlite",
+                cache_name=env.str("REQUESTS_CACHE_NAME", "http_cache"),
             )
         else:
             self.session = requests.Session()

--- a/reports/models.py
+++ b/reports/models.py
@@ -148,7 +148,9 @@ class Report(models.Model):
         return self.slug
 
     def refresh_cache_token(self):
+        """Refresh cache token to invalidate http cache and clear request cache for github requests related to this repo"""
         self.cache_token = uuid4()
+        GithubReport(self).clear_cache()
         self.save()
 
     @property

--- a/reports/views.py
+++ b/reports/views.py
@@ -29,7 +29,7 @@ def report_view(request, slug, cache_token=None):
         # Force an update by refreshing the cache_token and redirecting
         report.refresh_cache_token()
         logger.info(
-            "Cache token refreshed, redirecting...",
+            "Cache token refreshed and requests cache cleared; redirecting...",
             report_id=report.pk,
             slug=report.slug,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,7 @@ def researcher():
     yield user
 
 
-def _remove_cache_file_if_exists():
+def remove_cache_file_if_exists():
     test_cache_path = Path(__file__).parent.parent / "test_cache.sqlite"
     if test_cache_path.exists():  # pragma: no cover
         test_cache_path.unlink()
@@ -62,12 +62,12 @@ def pytest_sessionstart(session):
     logger = logging.getLogger("requests_cache")
     logger.setLevel("ERROR")
 
-    _remove_cache_file_if_exists()
+    remove_cache_file_if_exists()
 
 
 def pytest_sessionfinish(session, exitstatus):
     """clean up test cache files after session starts"""
-    _remove_cache_file_if_exists()  # pragma: no cover
+    remove_cache_file_if_exists()  # pragma: no cover
 
 
 @pytest.fixture(name="log_output", scope="module")

--- a/tests/reports/test_views.py
+++ b/tests/reports/test_views.py
@@ -340,7 +340,7 @@ def test_report_view_cache(client, log_output):
         {
             "report_id": report.id,
             "slug": report.slug,
-            "event": "Cache token refreshed, redirecting...",
+            "event": "Cache token refreshed and requests cache cleared; redirecting...",
         },
     )
     assert response.status_code == 302


### PR DESCRIPTION
When we do a `?force-update=` the http cache is invalidated by generating a new cache token for the url.  However, it continues to use the requests cache for github requests.  We can't just turn off requests caching for the force-update request, because it'll only apply for this forced request, and the next one will fall back to using the old stale cache, so we need to clear the cache for the urls relevant to this repo.

This will have the effect of clearing the cache for any requests related to the repo - so if there are 2 reports set up for the same repo, it'll clear the cache for all of them (but they should still be using their http cache, so it actually shouldn't impact them)