### PR TITLE
Remove duplicate "The" from footer template

### DIFF
--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -29,7 +29,7 @@
     </nav>
 
     <p class="mt-8 text-center text-sm text-gray-500 mx-auto max-w-xl">
-      &copy; University of Oxford for the The DataLab {% now 'Y' %}. This work may be copied freely for non-commercial research and study. If you wish to do any of the other acts restricted by the copyright you should apply in writing to <a class="font-semibold underline text-gray-600 hover:text-blue-800" href="mailto:ebmdatalab@phc.ox.ac.uk">ebmdatalab@phc.ox.ac.uk</a>.
+      &copy; University of Oxford for the DataLab {% now 'Y' %}. This work may be copied freely for non-commercial research and study. If you wish to do any of the other acts restricted by the copyright you should apply in writing to <a class="font-semibold underline text-gray-600 hover:text-blue-800" href="mailto:ebmdatalab@phc.ox.ac.uk">ebmdatalab@phc.ox.ac.uk</a>.
     </p>
   </div>
 </footer>


### PR DESCRIPTION
The rest of the site uses "the DataLab", so follow this style.