### PR TITLE
Revisit the caching again

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,5 +5,6 @@ set -euo pipefail
 ./manage.py migrate
 ./manage.py ensure_groups
 ./manage.py collectstatic --no-input
+./manage.py createcachetable
 
 exec "$@"

--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@ dev-config:
 	./scripts/dev-env.sh .env
 
 # set up/update the local dev env
-setup: pip-install npm-install migrate ensure-superuser ensure-reports ensure-groups collectstatic
+setup: pip-install npm-install migrate ensure-superuser ensure-reports ensure-groups collectstatic createcachetable
 
 # install correct versions of all Python dependencies
 pip-install:
@@ -56,6 +56,10 @@ ensure-reports:
 # ensure the researchers group exists with relevant permissions
 ensure-groups:
     ./manage.py ensure_groups
+
+# create the database cache table
+createcachetable:
+    ./manage.py createcachetable
 
 # blow away the local database and repopulate it
 dev-reset:

--- a/output_explorer/settings.py
+++ b/output_explorer/settings.py
@@ -198,3 +198,11 @@ initialise_sentry()
 
 # Needed for the debug context processor to work locally
 INTERNAL_IPS = ["127.0.0.1"]
+
+# Caching
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.db.DatabaseCache",
+        "LOCATION": "cache_table",
+    }
+}

--- a/reports/github.py
+++ b/reports/github.py
@@ -5,8 +5,11 @@ from pathlib import Path
 
 import requests
 import requests_cache
+from bs4 import BeautifulSoup
+from django.utils.safestring import mark_safe
 from environs import Env
 from furl import furl
+from lxml.html.clean import Cleaner
 
 
 env = Env()
@@ -222,6 +225,29 @@ class GithubReport:
             self.report.save()
 
         return file.decoded_content
+
+    def process_html(self):
+        html = self.get_html()
+        # We want to handle complete HTML documents and also fragments. We're going to extract the contents of the body
+        # at the end of this function, but it's easiest to normalize to complete documents because that's what the
+        # HTML-wrangling libraries we're using are most comfortable handling.
+        if "<html>" not in html:
+            html = f"<html><body>{html}</body></head>"
+
+        cleaned = Cleaner(
+            page_structure=False, style=True, kill_tags=["head"]
+        ).clean_html(html)
+
+        soup = BeautifulSoup(cleaned, "html.parser")
+
+        # For small screens we want to allow side-scrolling for just a small number of elements. To enable this each one
+        # needs to be wrapped in a div that we can target for styling.
+        for tag in ["table", "pre"]:
+            for element in soup.find_all(tag):
+                element.wrap(soup.new_tag("div", attrs={"class": "overflow-wrapper"}))
+
+        body_content = "".join([str(element) for element in soup.body.contents])
+        return mark_safe(body_content)
 
     def clear_cache(self):
         """Clear all request cache urls for this repo"""

--- a/reports/models.py
+++ b/reports/models.py
@@ -268,7 +268,7 @@ class Report(models.Model):
             )
 
     def get_absolute_url(self):
-        return reverse("reports:report_view", args=(self.slug, self.cache_token))
+        return reverse("reports:report_view", args=(self.slug,))
 
 
 class Link(models.Model):

--- a/reports/templates/reports/report.html
+++ b/reports/templates/reports/report.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-
+{% load cache %}
 {% load static %}
 {% load django_vite %}
 
@@ -16,130 +16,136 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto px-4 md:px-8">
-  <div class="bg-white shadow overflow-hidden sm:rounded-lg max-w-screen-lg mx-auto my-6">
-    <div class="px-4 py-5 sm:px-6">
-      {% if report.title %}
-        <h3 class="text-2xl leading-6 font-medium text-gray-900">
-          {{ report.title }}
-        </h3>
-      {% endif %}
-    </div>
-    <div class="border-t border-gray-200 px-4 py-5 sm:px-6">
-      <dl class="grid grid-cols-1 gap-x-4 gap-y-8 sm:grid-cols-2">
-        {% if report.description %}
-          <div class="sm:col-span-2">
-            <dt class="text-sm font-semibold text-gray-600">
-              Description
-            </dt>
-            <dd class="mt-1 text-sm text-gray-900">
-              {{ report.description }}
-            </dd>
+  {% with report_token=report.cache_token %}
+    {% cache 86400 report_content report_token %}
+      <div class="container mx-auto px-4 md:px-8">
+        <div class="bg-white shadow overflow-hidden sm:rounded-lg max-w-screen-lg mx-auto my-6">
+          <div class="px-4 py-5 sm:px-6">
+            {% if report.title %}
+              <h3 class="text-2xl leading-6 font-medium text-gray-900">
+                {{ report.title }}
+              </h3>
+            {% endif %}
           </div>
-        {% endif %}
-        {% if report.authors %}
-          <div class="sm:col-span-2">
-            <dt class="text-sm font-semibold text-gray-600">
-              Authors
-            </dt>
-            <dd class="mt-1 text-sm text-gray-900">
-              {{ report.authors }}
-            </dd>
+          <div class="border-t border-gray-200 px-4 py-5 sm:px-6">
+            <dl class="grid grid-cols-1 gap-x-4 gap-y-8 sm:grid-cols-2">
+              {% if report.description %}
+                <div class="sm:col-span-2">
+                  <dt class="text-sm font-semibold text-gray-600">
+                    Description
+                  </dt>
+                  <dd class="mt-1 text-sm text-gray-900">
+                    {{ report.description }}
+                  </dd>
+                </div>
+              {% endif %}
+              {% if report.authors %}
+                <div class="sm:col-span-2">
+                  <dt class="text-sm font-semibold text-gray-600">
+                    Authors
+                  </dt>
+                  <dd class="mt-1 text-sm text-gray-900">
+                    {{ report.authors }}
+                  </dd>
+                </div>
+              {% endif %}
+              <div class="sm:col-span-2">
+                <dt class="text-sm font-semibold text-gray-600">
+                  Contact
+                </dt>
+                <dd class="mt-1 text-sm text-gray-900">
+                  Get in touch and tell us how you use this report or new features you'd like to see:
+                  <a href="mailto:{{ report.contact_email }}" class="text-oxford-600 hover:text-oxford-800 font-semibold hover:underline">
+                    {{ report.contact_email }}
+                  </a>
+                </dd>
+              </div>
+              <div class="sm:col-span-1">
+                <dt class="text-sm font-semibold text-gray-600">
+                  First published
+                </dt>
+                <dd class="mt-1 text-sm text-gray-900">
+                  {{ report.publication_date|date:"d M Y"}}
+                </dd>
+              </div>
+              <div class="sm:col-span-1">
+                <dt class="text-sm font-semibold text-gray-600">
+                  Last updated
+                </dt>
+                <dd class="mt-1 text-sm text-gray-900">
+                  {{ report.last_updated|date:"d M Y"}}
+                </dd>
+              </div>
+
+              <div class="sm:col-span-2">
+                <dt class="text-sm font-semibold text-gray-600">
+                  Links
+                </dt>
+                {% for link in report.links.all %}
+                    <dd class="mt-1 text-sm text-gray-900">
+                      <ul class="border border-gray-200 rounded-md divide-y divide-gray-200">
+                        <li class="pl-3 pr-4 py-3 flex items-center justify-between text-sm">
+                          <div class="w-0 flex-1 flex items-center">
+                            {% if link.icon == "github" %}
+                              {% include "icons/brand/github.svg" with htmlClass="flex-shrink-0 h-5 w-5 text-gray-500" %}
+                            {% elif link.icon == "paper" %}
+                              {% include "icons/outline/newspaper.svg" with htmlClass="flex-shrink-0 h-5 w-5 text-gray-500" %}
+                            {% else %}
+                              {% include "icons/outline/paper-clip.svg" with htmlClass="flex-shrink-0 h-5 w-5 text-gray-500" %}
+                            {% endif %}
+                            <a href="{{ link.url }}" class="ml-2 text-oxford-600 hover:text-oxford-800 font-semibold hover:underline">
+                              {{ link.label }}
+                            </a>
+                          </div>
+                        </li>
+                      </ul>
+                    </dd>
+                  {% endfor %}
+              </div>
+            </dl>
           </div>
-        {% endif %}
-        <div class="sm:col-span-2">
-          <dt class="text-sm font-semibold text-gray-600">
-            Contact
-          </dt>
-          <dd class="mt-1 text-sm text-gray-900">
-            Get in touch and tell us how you use this report or new features you'd like to see:
-            <a href="mailto:{{ report.contact_email }}" class="text-oxford-600 hover:text-oxford-800 font-semibold hover:underline">
-              {{ report.contact_email }}
-            </a>
-          </dd>
-        </div>
-        <div class="sm:col-span-1">
-          <dt class="text-sm font-semibold text-gray-600">
-            First published
-          </dt>
-          <dd class="mt-1 text-sm text-gray-900">
-            {{ report.publication_date|date:"d M Y"}}
-          </dd>
-        </div>
-        <div class="sm:col-span-1">
-          <dt class="text-sm font-semibold text-gray-600">
-            Last updated
-          </dt>
-          <dd class="mt-1 text-sm text-gray-900">
-            {{ report.last_updated|date:"d M Y"}}
-          </dd>
         </div>
 
-        <div class="sm:col-span-2">
-          <dt class="text-sm font-semibold text-gray-600">
-            Links
-          </dt>
-          {% for link in report.links.all %}
-              <dd class="mt-1 text-sm text-gray-900">
-                <ul class="border border-gray-200 rounded-md divide-y divide-gray-200">
-                  <li class="pl-3 pr-4 py-3 flex items-center justify-between text-sm">
-                    <div class="w-0 flex-1 flex items-center">
-                      {% if link.icon == "github" %}
-                        {% include "icons/brand/github.svg" with htmlClass="flex-shrink-0 h-5 w-5 text-gray-500" %}
-                      {% elif link.icon == "paper" %}
-                        {% include "icons/outline/newspaper.svg" with htmlClass="flex-shrink-0 h-5 w-5 text-gray-500" %}
-                      {% else %}
-                        {% include "icons/outline/paper-clip.svg" with htmlClass="flex-shrink-0 h-5 w-5 text-gray-500" %}
-                      {% endif %}
-                      <a href="{{ link.url }}" class="ml-2 text-oxford-600 hover:text-oxford-800 font-semibold hover:underline">
-                        {{ link.label }}
-                      </a>
-                    </div>
-                  </li>
-                </ul>
-              </dd>
-            {% endfor %}
+        <div class="bg-white shadow overflow-hidden sm:rounded-lg max-w-screen-lg mx-auto my-6">
+          <div class="max-w-4xl mx-auto">
+            <div class="prose prose-sm sm:prose prose-oxford sm:prose-oxford px-8 sm:max-w-none mx-auto py-16">
+              {{ github_report.process_html }}
+            </div>
+          </div>
         </div>
-      </dl>
-    </div>
-  </div>
-
-  <div class="bg-white shadow overflow-hidden sm:rounded-lg max-w-screen-lg mx-auto my-6">
-    <div class="max-w-4xl mx-auto">
-      <div class="prose prose-sm sm:prose prose-oxford sm:prose-oxford px-8 sm:max-w-none mx-auto py-16">
-        {{ notebook_contents }}
       </div>
-    </div>
-  </div>
-</div>
+    {% endcache %}
+  {% endwith %}
 {% endblock %}
 
-
-
 {% block extra_js %}
-<script type="text/x-mathjax-config">
-  MathJax.Hub.Config({
-    tex2jax: {
-      inlineMath: [
-        ["$", "$"],
-        ["\\(", "\\)"],
-      ],
-      displayMath: [
-        ["$$", "$$"],
-        ["\\[", "\\]"],
-      ],
-      processEscapes: true,
-      processEnvironments: true,
-    },
-    // Center justify equations in code and markdown cells. Elsewhere
-    // we use CSS to left justify single line equations in code cells.
-    displayAlign: "center",
-    "HTML-CSS": {
-      styles: { ".MathJax_Display": { margin: 0 } },
-      linebreaks: { automatic: true },
-    },
-  });
-</script>
+  {% with report_token=report.cache_token %}
+    {% cache 86400 report_content report_token %}
+      <script type="text/x-mathjax-config">
+        MathJax.Hub.Config({
+          tex2jax: {
+            inlineMath: [
+              ["$", "$"],
+              ["\\(", "\\)"],
+            ],
+            displayMath: [
+              ["$$", "$$"],
+              ["\\[", "\\]"],
+            ],
+            processEscapes: true,
+            processEnvironments: true,
+          },
+          // Center justify equations in code and markdown cells. Elsewhere
+          // we use CSS to left justify single line equations in code cells.
+          displayAlign: "center",
+          "HTML-CSS": {
+            styles: { ".MathJax_Display": { margin: 0 } },
+            linebreaks: { automatic: true },
+          },
+        });
+      </script>
 
-{% vite_asset 'assets/scripts/notebook-legacy.js' scripts_attrs=scripts_attrs %}
+      {% vite_asset 'assets/scripts/notebook-legacy.js' scripts_attrs=scripts_attrs %}
+    {% endcache %}
+  {% endwith %}
 {% endblock %}

--- a/reports/urls.py
+++ b/reports/urls.py
@@ -7,8 +7,6 @@ from .views import report_view
 app_name = "reports"
 
 urlpatterns = [
-    path("<slug:slug>/<uuid:cache_token>/", report_view, name="report_view"),
-    path("<slug:slug>/<str:cache_token>/", report_view, name="report_view"),
     path("<slug:slug>/", report_view, name="report_view"),
     path("", RedirectView.as_view(url="/", permanent=True)),
 ]

--- a/reports/views.py
+++ b/reports/views.py
@@ -1,12 +1,8 @@
 import structlog
-from bs4 import BeautifulSoup
-from django.core.cache import cache
 from django.http import Http404
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
-from django.utils.safestring import mark_safe
 from django.views.decorators.cache import never_cache
-from lxml.html.clean import Cleaner
 
 from .github import GithubReport
 from .models import Report
@@ -43,37 +39,8 @@ def report_view(request, slug):
         request,
         "reports/report.html",
         {
-            "notebook_contents": process_html(github_report),
+            "github_report": github_report,
             "report": github_report.report,
             "repo_url": github_report.repo.url,
         },
     )
-
-
-def process_html(github_report):
-    # Fetch the processed html from the cache if available
-    cache_key = str(github_report.report.cache_token)
-    body_content = cache.get(cache_key)
-    if body_content is None:
-        html = github_report.get_html()
-        # We want to handle complete HTML documents and also fragments. We're going to extract the contents of the body
-        # at the end of this function, but it's easiest to normalize to complete documents because that's what the
-        # HTML-wrangling libraries we're using are most comfortable handling.
-        if "<html>" not in html:
-            html = f"<html><body>{html}</body></head>"
-
-        cleaned = Cleaner(
-            page_structure=False, style=True, kill_tags=["head"]
-        ).clean_html(html)
-
-        soup = BeautifulSoup(cleaned, "html.parser")
-
-        # For small screens we want to allow side-scrolling for just a small number of elements. To enable this each one
-        # needs to be wrapped in a div that we can target for styling.
-        for tag in ["table", "pre"]:
-            for element in soup.find_all(tag):
-                element.wrap(soup.new_tag("div", attrs={"class": "overflow-wrapper"}))
-
-        body_content = "".join([str(element) for element in soup.body.contents])
-        cache.set(cache_key, body_content, timeout=84600)
-    return mark_safe(body_content)

--- a/reports/views.py
+++ b/reports/views.py
@@ -1,5 +1,6 @@
 import structlog
 from bs4 import BeautifulSoup
+from django.core.cache import cache
 from django.http import Http404
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
@@ -37,38 +38,42 @@ def report_view(request, slug):
         )
         return redirect(report.get_absolute_url())
 
-    logger.info("Cache missed", report_id=report.pk, slug=report.slug)
     github_report = GithubReport(report)
     return TemplateResponse(
         request,
         "reports/report.html",
         {
-            "notebook_contents": process_html(github_report.get_html()),
+            "notebook_contents": process_html(github_report),
             "report": github_report.report,
             "repo_url": github_report.repo.url,
         },
     )
 
 
-def process_html(html):
-    # We want to handle complete HTML documents and also fragments. We're going to extract the contents of the body
-    # at the end of this function, but it's easiest to normalize to complete documents because that's what the
-    # HTML-wrangling libraries we're using are most comfortable handling.
-    if "<html>" not in html:
-        html = f"<html><body>{html}</body></head>"
+def process_html(github_report):
+    # Fetch the processed html from the cache if available
+    cache_key = str(github_report.report.cache_token)
+    body_content = cache.get(cache_key)
+    if body_content is None:
+        html = github_report.get_html()
+        # We want to handle complete HTML documents and also fragments. We're going to extract the contents of the body
+        # at the end of this function, but it's easiest to normalize to complete documents because that's what the
+        # HTML-wrangling libraries we're using are most comfortable handling.
+        if "<html>" not in html:
+            html = f"<html><body>{html}</body></head>"
 
-    cleaned = Cleaner(page_structure=False, style=True, kill_tags=["head"]).clean_html(
-        html
-    )
+        cleaned = Cleaner(
+            page_structure=False, style=True, kill_tags=["head"]
+        ).clean_html(html)
 
-    soup = BeautifulSoup(cleaned, "html.parser")
+        soup = BeautifulSoup(cleaned, "html.parser")
 
-    # For small screens we want to allow side-scrolling for just a small number of elements. To enable this each one
-    # needs to be wrapped in a div that we can target for styling.
-    for tag in ["table", "pre"]:
-        for element in soup.find_all(tag):
-            element.wrap(soup.new_tag("div", attrs={"class": "overflow-wrapper"}))
+        # For small screens we want to allow side-scrolling for just a small number of elements. To enable this each one
+        # needs to be wrapped in a div that we can target for styling.
+        for tag in ["table", "pre"]:
+            for element in soup.find_all(tag):
+                element.wrap(soup.new_tag("div", attrs={"class": "overflow-wrapper"}))
 
-    body_content = "".join([str(element) for element in soup.body.contents])
-
+        body_content = "".join([str(element) for element in soup.body.contents])
+        cache.set(cache_key, body_content, timeout=84600)
     return mark_safe(body_content)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ from social_django.utils import load_strategy
 from structlog.testing import LogCapture
 
 from gateway.backends import NHSIDConnectAuth
+from reports.github import GithubReport
 
 from .gateway.mocks import OPENID_CONFIG
 
@@ -132,13 +133,20 @@ def skip_github_validation(reset_environment_after_test):
     environ["GITHUB_VALIDATION"] = "False"
 
 
+class MockGithubReport(GithubReport):
+    def __init__(self, report, html):
+        self.report = report
+        self.html = html
+
+    def get_html(self):
+        return self.html
+
+
 @pytest.fixture
 def mock_github_report_with_html(mocker):
     def create_report(html):
         report = baker.make_recipe("reports.dummy_report")
-        mock_report = mocker.Mock()
-        mock_report.report = report
-        mock_report.get_html.return_value = html
+        mock_report = MockGithubReport(report, html)
         return mock_report
 
     return create_report

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,6 +132,18 @@ def skip_github_validation(reset_environment_after_test):
     environ["GITHUB_VALIDATION"] = "False"
 
 
+@pytest.fixture
+def mock_github_report_with_html(mocker):
+    def create_report(html):
+        report = baker.make_recipe("reports.dummy_report")
+        mock_report = mocker.Mock()
+        mock_report.report = report
+        mock_report.get_html.return_value = html
+        return mock_report
+
+    return create_report
+
+
 baker.generators.add(
     "reports.models.AutoPopulatingCharField",
     baker.generators.default_mapping[django.db.models.CharField],


### PR DESCRIPTION
We've been caching the entire Report page, however this turns out not to be ideal because it caches everything, including the side menu, which needs to change when users log in and out.

Instead, we now cache just the template fragment that contains the report content, using the report's cache_token as a key.  This means that a cache update can be forced as before, by using `?force-update=` or the django admin action, but we no longer need to include a cache token in the url.

Since it now calls the view rather than caching it altogether, we also manually cache the results of processing the html retrieved from github, so we don't need to redo this each time (the request itself is already cached).