### PR TITLE
Remove backticks from inline code blocks

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -44,6 +44,12 @@ module.exports = {
               color: theme("colors.blue.900"),
               "text-decoration": "underline",
             },
+            'code::before': {
+              content: ''
+            },
+            'code::after': {
+              content: ''
+            }
           },
         },
       }),


### PR DESCRIPTION
So that inline code comments don't show additional characters.