### PR TITLE
Hidden archive category for reports

### DIFF
--- a/reports/management/commands/populate_reports.py
+++ b/reports/management/commands/populate_reports.py
@@ -10,6 +10,7 @@ class Command(BaseCommand):
     help = "Populate the database with sample reports if they are not already there. For development use only."
 
     def handle(self, *args, **options):
+        Category.objects.get_or_create(name="Archive")
         category, _ = Category.objects.get_or_create(name="Reports")
 
         self.ensure_report(

--- a/reports/models.py
+++ b/reports/models.py
@@ -62,7 +62,12 @@ class PopulatedCategoryManager(models.Manager):
         report_category_ids = set(
             Report.objects.for_user(user).values_list("category_id", flat=True)
         )
-        return self.get_queryset().filter(id__in=report_category_ids).order_by("name")
+        queryset = (
+            self.get_queryset().filter(id__in=report_category_ids).order_by("name")
+        )
+        if user.is_staff:
+            return queryset
+        return queryset.exclude(name__iexact="archive")
 
 
 class Category(models.Model):

--- a/tests/reports/test_models.py
+++ b/tests/reports/test_models.py
@@ -107,6 +107,29 @@ def test_category_for_user(user_no_permission, user_with_permission, mock_repo_u
 
 
 @pytest.mark.django_db
+def test_archive_category_for_user(
+    user_no_permission, user_with_permission, mock_repo_url
+):
+    # Archive category is never returned in the populated_for_user manager
+    category = Category.objects.first()
+    archive_category = baker.make(Category, name="Archive")
+    mock_repo_url("https://github.com/opensafely/test-repo")
+    baker.make_recipe("reports.dummy_report", category=category)
+    baker.make_recipe("reports.dummy_report", category=archive_category)
+
+    user = AnonymousUser()
+    assert list(Category.populated.for_user(user)) == list(
+        Category.objects.filter(id=category.id)
+    )
+    assert list(Category.populated.for_user(user_no_permission)) == list(
+        Category.objects.filter(id=category.id)
+    )
+    assert list(Category.populated.for_user(user_with_permission)) == list(
+        Category.objects.filter(id=category.id)
+    )
+
+
+@pytest.mark.django_db
 def test_report_menu_name_autopopulates():
     category = baker.make(Category, name="test")
     report = Report(

--- a/tests/reports/test_views.py
+++ b/tests/reports/test_views.py
@@ -241,6 +241,19 @@ def test_report_view(client):
 
 
 @pytest.mark.django_db
+def test_archive_report_view(client):
+    """Test that an archive report is accessible, but not listed in categories"""
+    category = Category.objects.first()
+    baker.make_recipe("reports.real_report", category=category)
+    archive_report = baker.make_recipe("reports.real_report", category__name="Archive")
+
+    response = client.get(archive_report.get_absolute_url())
+    assert response.status_code == 200
+    assert response.context["report"] == archive_report
+    assert [category.id for category in response.context["categories"]] == [category.id]
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     "user_attributes,is_draft,expected_status",
     [


### PR DESCRIPTION
Fixes #161 

MVP for having multiple versions of reports - a special "Archive" category for reports which are accessible by direct link, but don't show up in the menu categories.