### PR TITLE
Update Django Vite package and remove scripts_attrs

### DIFF
--- a/reports/context_processors.py
+++ b/reports/context_processors.py
@@ -4,5 +4,4 @@ from .models import Category
 def reports(request):
     return {
         "categories": Category.populated.for_user(request.user),
-        "scripts_attrs": {"nomodule": ""},
     }

--- a/reports/templates/reports/report.html
+++ b/reports/templates/reports/report.html
@@ -154,8 +154,8 @@
         });
       </script>
 
-      {% vite_asset 'vite/legacy-polyfills' scripts_attrs=scripts_attrs %}
-      {% vite_asset 'assets/src/scripts/notebook-legacy.js' scripts_attrs=scripts_attrs %}
+      {% vite_legacy_polyfills %}
+      {% vite_legacy_asset 'assets/src/scripts/notebook-legacy.js' %}
     {% endcache %}
   {% endwith %}
 {% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -159,6 +159,13 @@ dj-email-url==1.0.2 \
     --hash=sha256:15148141c6ef123636e4ca3663e95231ed94ca5ed267e91977e5a4397be8b34c \
     --hash=sha256:838fd4ded9deba53ae757debef431e25fa7fca31d3948b3c4808ccdc84fab2b7
     # via environs
+django==3.2.6 \
+    --hash=sha256:7f92413529aa0e291f3be78ab19be31aefb1e1c9a52cd59e130f505f27a51f13 \
+    --hash=sha256:f27f8544c9d4c383bbe007c57e3235918e258364577373d4920e9162837be022
+    # via
+    #   django-extensions
+    #   django-structlog
+    #   django-vite
 django-cache-url==3.2.3 \
     --hash=sha256:5514ca3a2075c6b956b3d0a5c540654d32b004e76340d7bdabf6661135b5f218 \
     --hash=sha256:c1d45626ae8a206267c1263aa7a3461e2e186be2e939bcbd8c660e25851ddac8
@@ -175,17 +182,10 @@ django-structlog==2.1.1 \
     --hash=sha256:1531ca6a029d57babec5182a6b2ea9c33edfc6f9190d95826db14861e0cd4c2f \
     --hash=sha256:177de7440873043dc9517862c0ea84713c16ff25849359351255e23fa42bb593
     # via -r requirements.in
-django-vite==1.1.1 \
-    --hash=sha256:25ed9257fc104c1dfecb18805b165f6750297296ba2cfa86d9bd48a099c8946e \
-    --hash=sha256:4bcf05f6e79350109cbabbeec57ecb11d3c457608c6908a25e1c499765833c5f
+django-vite==1.2 \
+    --hash=sha256:2419da8575b180632e987bd9f34a84ed26804cdd1801496cc59e2cee6760b85c \
+    --hash=sha256:41834a66500c0d7de484347e4669f9f76ed9dffaa53b2ddd2190fdd2ea1352a9
     # via -r requirements.in
-django==3.2.6 \
-    --hash=sha256:7f92413529aa0e291f3be78ab19be31aefb1e1c9a52cd59e130f505f27a51f13 \
-    --hash=sha256:f27f8544c9d4c383bbe007c57e3235918e258364577373d4920e9162837be022
-    # via
-    #   django-extensions
-    #   django-structlog
-    #   django-vite
 ecdsa==0.17.0 \
     --hash=sha256:5cf31d5b33743abe0dfc28999036c849a69d548f994b535e527ee3cb7f3ef676 \
     --hash=sha256:b9f500bb439e4153d0330610f5d26baaf18d17b8ced1bc54410d189385ea68aa
@@ -341,6 +341,14 @@ pyyaml==5.4.1 \
     --hash=sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6 \
     --hash=sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0
     # via requests-cache
+requests==2.26.0 \
+    --hash=sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24 \
+    --hash=sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7
+    # via
+    #   osgithub
+    #   requests-cache
+    #   requests-oauthlib
+    #   social-auth-core
 requests-cache==0.7.4 \
     --hash=sha256:4786190991b5f9e8ecfa97a1a6fd02475486e522a6d62f4bea53c32a7c1172c9 \
     --hash=sha256:ca7b7d138033dffb07922856a55d51934497024f1d5b8425acbcfa58ee97269f
@@ -351,14 +359,6 @@ requests-oauthlib==1.3.0 \
     --hash=sha256:7f71572defaecd16372f9006f33c2ec8c077c3cfa6f5911a9a90202beb513f3d \
     --hash=sha256:b4261601a71fd721a8bd6d7aa1cc1d6a8a93b4a9f5e96626f8e4d91e8beeaa6a
     # via social-auth-core
-requests==2.26.0 \
-    --hash=sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24 \
-    --hash=sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7
-    # via
-    #   osgithub
-    #   requests-cache
-    #   requests-oauthlib
-    #   social-auth-core
 rsa==4.7.2 \
     --hash=sha256:78f9a9bf4e7be0c5ded4583326e7461e3a3c5aae24073648b4bdfa797d78c9d2 \
     --hash=sha256:9d689e6ca1b3038bc82bf8d23e944b6b6037bc02301a574935b2dd946e0353b9

--- a/templates/base.html
+++ b/templates/base.html
@@ -51,8 +51,8 @@
 
   {# Legacy browsers #}
   <script nomodule src="{% static 'vendor/alpine-ie11.js' %}"></script>
-  {% vite_asset "vite/legacy-polyfills" scripts_attrs=scripts_attrs %}
-  {% vite_asset 'assets/src/scripts/main-legacy.js' scripts_attrs=scripts_attrs %}
+  {% vite_legacy_polyfills %}
+  {% vite_legacy_asset 'assets/src/scripts/main-legacy.js' %}
 
   {% block extra_js %}{% endblock %}
 </body>


### PR DESCRIPTION
As part of the django-vite package upgrade, we now don't need our custom scripts_attrs from the content processors.

Closes https://github.com/opensafely-core/output-explorer/pull/197