### PR TITLE
Remove duplicate report and caching of extra_js

### DIFF
--- a/reports/templates/reports/report.html
+++ b/reports/templates/reports/report.html
@@ -128,34 +128,30 @@
 {% endblock %}
 
 {% block extra_js %}
-  {% with report_token=report.cache_token %}
-    {% cache 86400 report_content report_token %}
-      <script type="text/x-mathjax-config">
-        MathJax.Hub.Config({
-          tex2jax: {
-            inlineMath: [
-              ["$", "$"],
-              ["\\(", "\\)"],
-            ],
-            displayMath: [
-              ["$$", "$$"],
-              ["\\[", "\\]"],
-            ],
-            processEscapes: true,
-            processEnvironments: true,
-          },
-          // Center justify equations in code and markdown cells. Elsewhere
-          // we use CSS to left justify single line equations in code cells.
-          displayAlign: "center",
-          "HTML-CSS": {
-            styles: { ".MathJax_Display": { margin: 0 } },
-            linebreaks: { automatic: true },
-          },
-        });
-      </script>
+  <script type="text/x-mathjax-config">
+    MathJax.Hub.Config({
+      tex2jax: {
+        inlineMath: [
+          ["$", "$"],
+          ["\\(", "\\)"],
+        ],
+        displayMath: [
+          ["$$", "$$"],
+          ["\\[", "\\]"],
+        ],
+        processEscapes: true,
+        processEnvironments: true,
+      },
+      // Center justify equations in code and markdown cells. Elsewhere
+      // we use CSS to left justify single line equations in code cells.
+      displayAlign: "center",
+      "HTML-CSS": {
+        styles: { ".MathJax_Display": { margin: 0 } },
+        linebreaks: { automatic: true },
+      },
+    });
+  </script>
 
-      {% vite_legacy_polyfills %}
-      {% vite_legacy_asset 'assets/src/scripts/notebook-legacy.js' %}
-    {% endcache %}
-  {% endwith %}
+  {% vite_legacy_polyfills %}
+  {% vite_legacy_asset 'assets/src/scripts/notebook-legacy.js' %}
 {% endblock %}


### PR DESCRIPTION
Linked to #227 

The `extra_js` block contains caching which is causing the report to be loaded twice, once outside of the viewport just above the `<body />` tag. This is bloating the HTML size, causes issues with accessibility and makes future styling changes more difficult.

By removing the caching in the `extra_js` block, the HTML size goes from 13.1mb to 8.9mb on the Vaccine Coverage report.

<img width="1184" alt="Screenshot 2022-01-06 at 12 09 09" src="https://user-images.githubusercontent.com/24863179/148381109-cda9857b-d84b-4d93-86d3-48048c29ba3e.png">