### PR TITLE
Improve report semantic HTML, state and styling

### DIFF
--- a/reports/templates/reports/report.html
+++ b/reports/templates/reports/report.html
@@ -18,111 +18,104 @@
 {% block content %}
   {% with report_token=report.cache_token %}
     {% cache 86400 report_content report_token %}
-      <div class="container mx-auto px-4 md:px-8">
-        <div class="bg-white shadow overflow-hidden sm:rounded-lg max-w-screen-lg mx-auto my-6">
-          <div class="px-4 py-5 sm:px-6">
-            {% if report.title %}
-              <h3 class="text-2xl leading-6 font-medium text-gray-900">
-                {{ report.title }}
-              </h3>
+      <article class="md:container mx-auto md:px-8">
+
+        <header class="max-w-screen-lg mx-auto md:my-6 bg-white border-b border-gray-200 md:shadow md:rounded-lg">
+          {% if report.title %}
+          <h3 class="py-5 px-4 md:px-6 text-2xl leading-6 font-medium text-gray-900">
+            {{ report.title }}
+          </h3>
+          {% endif %}
+
+          <dl class="border-t border-gray-200 py-5 px-4 lg:px-6 text-gray-900 text-sm">
+
+            {% if report.description %}
+            <dt class="mb-1 font-semibold">
+              Description
+            </dt>
+            <dd class="mb-4">
+              {{ report.description }}
+            </dd>
             {% endif %}
-          </div>
-          <div class="border-t border-gray-200 px-4 py-5 sm:px-6">
-            <dl class="grid grid-cols-1 gap-x-4 gap-y-8 sm:grid-cols-2">
-              {% if report.description %}
-                <div class="sm:col-span-2">
-                  <dt class="text-sm font-semibold text-gray-600">
-                    Description
-                  </dt>
-                  <dd class="mt-1 text-sm text-gray-900">
-                    {{ report.description }}
-                  </dd>
-                </div>
-              {% endif %}
-              {% if report.authors %}
-                <div class="sm:col-span-2">
-                  <dt class="text-sm font-semibold text-gray-600">
-                    Authors
-                  </dt>
-                  <dd class="mt-1 text-sm text-gray-900">
-                    {{ report.authors }}
-                  </dd>
-                </div>
-              {% endif %}
-              <div class="sm:col-span-2">
-                <dt class="text-sm font-semibold text-gray-600">
-                  Contact
-                </dt>
-                <dd class="mt-1 text-sm text-gray-900">
-                  Get in touch and tell us how you use this report or new features you'd like to see:
-                  <a href="mailto:{{ report.contact_email }}" class="text-oxford-600 hover:text-oxford-800 font-semibold hover:underline">
-                    {{ report.contact_email }}
-                  </a>
-                </dd>
-              </div>
-              <div class="sm:col-span-1">
-                <dt class="text-sm font-semibold text-gray-600">
-                  First published
-                </dt>
-                <dd class="mt-1 text-sm text-gray-900">
-                  {{ report.publication_date|date:"d M Y"}}
-                </dd>
-              </div>
-              <div class="sm:col-span-1">
-                <dt class="text-sm font-semibold text-gray-600">
-                  Last updated
-                </dt>
-                <dd class="mt-1 text-sm text-gray-900">
-                  {{ report.last_updated|date:"d M Y"}}
-                </dd>
-              </div>
-              {% if report.doi %}
-              <div class="sm:col-span-2">
-                <p class="mt-1 text-sm text-gray-900">
-                  <a href="{{ report.doi }}" class="text-oxford-600 hover:text-oxford-800 font-semibold hover:underline">
-                    {{ report.doi }}
-                  </a>
-                </p>
-              </div>
-              {% endif %}
 
-              <div class="sm:col-span-2">
-                <dt class="text-sm font-semibold text-gray-600">
-                  Links
-                </dt>
-                {% for link in report.links.all %}
-                    <dd class="mt-1 text-sm text-gray-900">
-                      <ul class="border border-gray-200 rounded-md divide-y divide-gray-200">
-                        <li class="pl-3 pr-4 py-3 flex items-center justify-between text-sm">
-                          <div class="w-0 flex-1 flex items-center">
-                            {% if link.icon == "github" %}
-                              {% include "icons/brand/github.svg" with htmlClass="flex-shrink-0 h-5 w-5 text-gray-500" %}
-                            {% elif link.icon == "paper" %}
-                              {% include "icons/outline/newspaper.svg" with htmlClass="flex-shrink-0 h-5 w-5 text-gray-500" %}
-                            {% else %}
-                              {% include "icons/outline/paper-clip.svg" with htmlClass="flex-shrink-0 h-5 w-5 text-gray-500" %}
-                            {% endif %}
-                            <a href="{{ link.url }}" class="ml-2 text-oxford-600 hover:text-oxford-800 font-semibold hover:underline">
-                              {{ link.label }}
-                            </a>
-                          </div>
-                        </li>
-                      </ul>
-                    </dd>
-                  {% endfor %}
-              </div>
-            </dl>
-          </div>
-        </div>
+            {% if report.authors %}
+            <dt class="mb-1 font-semibold">
+              Authors
+            </dt>
+            <dd class="mb-4">
+              {{ report.authors }}
+            </dd>
+            {% endif %}
 
-        <div class="bg-white shadow overflow-hidden sm:rounded-lg max-w-screen-lg mx-auto my-6">
+            <dt class="mb-1 font-semibold">
+              Contact
+            </dt>
+            <dd class="mb-4">
+              Get in touch and tell us how you use this report or new features you'd like to see:
+              <a href="mailto:{{ report.contact_email }}" class="text-oxford-600 hover:text-oxford-800 font-semibold hover:underline">
+                {{ report.contact_email }}
+              </a>
+            </dd>
+
+            <div class="flex sm:inline-flex flex-col">
+              <dt class="mb-1 font-semibold">
+                First published
+              </dt>
+              <dd class="mb-4">
+                {{ report.publication_date|date:"d M Y"}}
+              </dd>
+            </div>
+            <div class="flex sm:inline-flex flex-col sm:ml-16">
+              <dt class="mb-1 font-semibold">
+                Last updated
+              </dt>
+              <dd class="mb-4">
+                {{ report.last_updated|date:"d M Y"}}
+              </dd>
+            </div>
+
+            {% if report.doi %}
+            <dt class="sr-only">DOI</dt>
+            <dd class="w-full">
+              <a href="{{ report.doi }}" class="mb-4 text-oxford-600 hover:text-oxford-800 font-semibold hover:underline">
+              {{ report.doi }}
+              </a>
+            </dd>
+            {% endif %}
+
+            <dt class="font-semibold">
+              Links
+            </dt>
+            {% for link in report.links.all %}
+            <dd class="mt-1">
+              <ul class="border border-gray-200 rounded-md divide-y divide-gray-200">
+                <li class="pl-3 pr-4 py-3 flex items-center">
+                  {% if link.icon == "github" %}
+                    {% include "icons/brand/github.svg" with htmlClass="flex-shrink-0 h-5 w-5 text-gray-600" %}
+                  {% elif link.icon == "paper" %}
+                    {% include "icons/outline/newspaper.svg" with htmlClass="flex-shrink-0 h-5 w-5 text-gray-600" %}
+                  {% else %}
+                    {% include "icons/outline/paper-clip.svg" with htmlClass="flex-shrink-0 h-5 w-5 text-gray-600" %}
+                  {% endif %}
+                  <a href="{{ link.url }}" class="ml-2 text-oxford-600 hover:text-oxford-800 font-semibold hover:underline">
+                    {{ link.label }}
+                  </a>
+                </li>
+              </ul>
+            </dd>
+            {% endfor %}
+
+          </dl>
+        </header>
+
+        <section class="bg-white md:shadow md:rounded-lg max-w-screen-lg mx-auto md:my-6">
           <div class="max-w-4xl mx-auto">
-            <div class="prose prose-sm sm:prose prose-oxford sm:prose-oxford px-8 sm:max-w-none mx-auto py-16">
+            <div class="prose prose-oxford sm:prose-oxford px-4 md:px-8 sm:max-w-none mx-auto py-4 md:py-8 lg:py-16">
               {{ github_report.process_html }}
             </div>
           </div>
-        </div>
-      </div>
+        </section>
+      </article>
     {% endcache %}
   {% endwith %}
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -39,7 +39,7 @@
       {% include "partials/header.html" %}
 
       <div class="flex flex-col flex-1 relative lg:overflow-y-auto overflow-x-hidden">
-        <main class="flex-auto flex-shrink-0 pb-16 bg-gray-50">
+        <main class="flex-auto flex-shrink-0 pt-6 pb-16 bg-gray-50">
           {% include "partials/alert.html" %}
           {% block content %}{% endblock content %}
         </main>

--- a/templates/base.html
+++ b/templates/base.html
@@ -2,7 +2,7 @@
 {% load django_vite %}
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" x-data="{ isSidebarVisible: false }" @keydown.window.escape="isSidebarVisible = false">
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -32,7 +32,7 @@
   <link rel="manifest" href="{% static 'manifest.webmanifest' %}">
 </head>
 <body class="lg:overflow-y-hidden">
-  <div x-data="{ open: false }" @keydown.window.escape="open = false" class="pt-12 lg:pt-0 lg:h-screen flex overflow-hidden bg-white">
+  <div class="pt-12 lg:pt-0 lg:h-screen flex overflow-hidden bg-white">
     {% include "partials/sidebar.html" %}
 
     <div class="ie-block flex flex-col w-0 flex-1 overflow-hidden">

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -1,5 +1,5 @@
 <div class="fixed top-0 min-w-full lg:relative z-10 flex-shrink-0 flex h-16 bg-white border-b border-gray-200">
-  <button type="button" @click="open = true" class="px-4 border-r border-gray-200 text-gray-500 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-oxford-700 lg:hidden">
+  <button type="button" @click="isSidebarVisible = true" class="px-4 border-r border-gray-200 text-gray-500 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-oxford-700 lg:hidden">
     <span class="sr-only">Open sidebar</span>
     {% include "icons/outline/menu-alt-2.svg" with htmlClass="h-6 w-6" %}
   </button>
@@ -15,9 +15,9 @@
 
     <div class="ml-4 flex items-center lg:ml-6">
         {% if user.is_authenticated %}
-          <div class="relative inline-block text-left" x-data="{ open: false }">
+          <div class="relative inline-block text-left" x-data="{ isSidebarVisible: false }">
             <div>
-              <button type="button" class="inline-flex justify-center w-full rounded-md px-1 py-1 overflow-hidden bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-100 focus:ring-oxford-700" id="menu-button" x-bind:aria-expanded="open.toString()" aria-haspopup="true" @click="open = true">
+              <button type="button" class="inline-flex justify-center w-full rounded-md px-1 py-1 overflow-hidden bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-100 focus:ring-oxford-700" id="menu-button" x-bind:aria-expanded="isSidebarVisible.toString()" aria-haspopup="true" @click="isSidebarVisible = true">
                 <span class="sr-only">Options</span>
                 <span class="inline-block h-10 w-10 rounded-full overflow-hidden bg-gray-100">
                   {% include "icons/solid/user.svg" with htmlClass="h-full w-full text-gray-300 relative -bottom-1" %}
@@ -25,14 +25,14 @@
               </button>
             </div>
             <div
-              @click.away="open = false"
+              @click.away="isSidebarVisible = false"
               aria-labelledby="menu-button"
               aria-orientation="vertical"
               class="origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 divide-y divide-gray-100 focus:outline-none"
               role="menu"
               x-cloak
-              x-show.transition="open"
-              x-show="open"
+              x-show.transition="isSidebarVisible"
+              x-show="isSidebarVisible"
               x-transition:enter-end="transform opacity-100 scale-100"
               x-transition:enter-start="transform opacity-0 scale-95"
               x-transition:enter="transition ease-out duration-100"

--- a/templates/partials/sidebar.html
+++ b/templates/partials/sidebar.html
@@ -6,13 +6,13 @@
   class="fixed inset-0 flex z-40 lg:hidden"
   x-cloak
   x-ref="dialog"
-  x-show="open">
+  x-show="isSidebarVisible">
   <div
-    @click="open = false"
+    @click="isSidebarVisible = false"
     aria-hidden="true"
     class="fixed inset-0 bg-gray-600 bg-opacity-75"
     x-cloak
-    x-show="open"
+    x-show="isSidebarVisible"
     x-transition:enter-end="opacity-100"
     x-transition:enter-start="opacity-0"
     x-transition:enter="transition-opacity ease-linear duration-300"
@@ -22,7 +22,7 @@
     <div
       class="relative flex-1 flex flex-col max-w-xs w-full pb-4 bg-oxford-800"
       x-cloak
-      x-show="open"
+      x-show="isSidebarVisible"
       x-transition:enter-end="translate-x-0"
       x-transition:enter-start="-translate-x-full"
       x-transition:enter="transition ease-in-out duration-300 transform"
@@ -32,14 +32,14 @@
       <div
         class="absolute top-0 right-0 -mr-12 pt-2"
         x-cloak
-        x-show="open"
+        x-show="isSidebarVisible"
         x-transition:enter-end="opacity-100"
         x-transition:enter-start="opacity-0"
         x-transition:enter="ease-in-out duration-300"
         x-transition:leave-end="opacity-0"
         x-transition:leave-start="opacity-100"
         x-transition:leave="ease-in-out duration-300">
-        <button type="button" @click="open = false" class="ml-1 flex items-center justify-center h-10 w-10 rounded-full focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white">
+        <button type="button" @click="isSidebarVisible = false" class="ml-1 flex items-center justify-center h-10 w-10 rounded-full focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white">
           <span class="sr-only">Close sidebar</span>
           {% include "icons/outline/x.svg" with htmlClass="h-6 w-6 text-white" attrs="aria-hidden='true'" %}
         </button>
@@ -67,22 +67,22 @@
               <nav class="flex-1 px-2 space-y-1 bg-oxford-800" aria-label="Sidebar">
                 <ul>
                   {% for category in categories %}
-                    <li x-data="{ open: {% if report.category.id == category.id %}true{% else %}false{% endif %} }" class="space-y-1">
+                    <li x-data="{ isSubmenuOpen: {% if report.category.id == category.id %}true{% else %}false{% endif %} }" class="space-y-1">
                       <button
-                        @click="open = !open"
+                        @click="isSubmenuOpen = !isSubmenuOpen"
                         aria-controls="mobile-sidebar-{{ forloop.counter }}"
                         aria-expanded="false"
                         class="text-white hover:bg-oxford-900 hover:text-gray-50 group w-full flex items-center pr-2 py-2 text-left text-sm font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-oxford-400"
                         type="button"
-                        x-bind:aria-expanded="open.toString()">
-                        {% include "icons/outline/chevron-right.svg" with htmlClass="text-gray-300 mr-2 flex-shrink-0 h-5 w-5 transform group-hover:text-gray-400 transition-colors ease-in-out duration-150" attrs=":class=\"{ 'text-gray-400 rotate-90': open, 'text-gray-300': !(open) }\"" %}
+                        x-bind:aria-expanded="isSubmenuOpen.toString()">
+                        {% include "icons/outline/chevron-right.svg" with htmlClass="text-gray-300 mr-2 flex-shrink-0 h-5 w-5 transform group-hover:text-gray-400 transition-colors ease-in-out duration-150" attrs=":class=\"{ 'text-gray-400 rotate-90': isSubmenuOpen, 'text-gray-300': !(isSubmenuOpen) }\"" %}
                         {{ category.name }}
                       </button>
                       <ul
                         class="space-y-1"
                         id="mobile-sidebar-{{ forloop.counter }}"
                         x-cloak
-                        x-show="open">
+                        x-show="isSubmenuOpen">
                         {% category_reports_for_user category as category_reports %}
                         {% for single_report in category_reports %}
                           <li>
@@ -136,21 +136,21 @@
               <nav class="flex-1 px-2 space-y-1 bg-oxford-800" aria-label="Sidebar">
                   <ul>
                     {% for category in categories %}
-                      <li x-data="{ open: {% if report.category.id == category.id %}true{% else %}false{% endif %} }" class="space-y-1">
+                      <li x-data="{ isSubmenuOpen: {% if report.category.id == category.id %}true{% else %}false{% endif %} }" class="space-y-1">
                         <button
-                          @click="open = !open"
+                          @click="isSubmenuOpen = !isSubmenuOpen"
                           aria-controls="desktop-sidebar-{{ forloop.counter }}"
                           aria-expanded="false"
                           class="text-white hover:bg-oxford-900 hover:text-gray-50 group w-full flex items-center pr-2 py-2 text-left text-sm font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-oxford-400"
                           type="button"
-                          x-bind:aria-expanded="open.toString()">
-                          {% include "icons/outline/chevron-right.svg" with htmlClass="text-gray-300 mr-2 flex-shrink-0 h-5 w-5 transform group-hover:text-gray-400 transition-colors ease-in-out duration-150" attrs=":class=\"{ 'text-gray-400 rotate-90': open, 'text-gray-300': !(open) }\"" %}
+                          x-bind:aria-expanded="isSubmenuOpen.toString()">
+                          {% include "icons/outline/chevron-right.svg" with htmlClass="text-gray-300 mr-2 flex-shrink-0 h-5 w-5 transform group-hover:text-gray-400 transition-colors ease-in-out duration-150" attrs=":class=\"{ 'text-gray-400 rotate-90': isSubmenuOpen, 'text-gray-300': !(isSubmenuOpen) }\"" %}
                           {{ category.name }}
                         </button>
                         <ul
                           class="space-y-1"
                           id="desktop-sidebar-{{ forloop.counter }}"
-                          x-show="open"
+                          x-show="isSubmenuOpen"
                           x-cloak>
                             {% category_reports_for_user category as category_reports %}
                             {% for single_report in category_reports %}


### PR DESCRIPTION
Linked to #227 

- Improve semantic HTML used in reports
- Improve mobile styling of reports
- Rename AlpineJS state from `open` to `isSidebarVisible` and `isSubmenuOpen`
- Move sidebar state to the `<html/>` element