### PR TITLE
Updates to styling and UI

### DIFF
--- a/assets/src/styles/main.scss
+++ b/assets/src/styles/main.scss
@@ -7,8 +7,29 @@
   display: none !important;
 }
 
+:root {
+  --animation-duration: 1s;
+  --transiton-duration: 0.5s;
+}
 html {
-  scroll-padding-top: 70px;
+  scroll-behavior: smooth;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --animation-duration: 0;
+    --transiton-duration: 0;
+  }
+
+  html {
+    scroll-behavior: auto;
+  }
+}
+
+@media (max-width: 1024px) {
+  html {
+    scroll-padding-top: 4rem;
+  }
 }
 
 #skip-link {

--- a/assets/src/styles/main.scss
+++ b/assets/src/styles/main.scss
@@ -11,6 +11,10 @@ html {
   scroll-padding-top: 70px;
 }
 
+#skip-link {
+  @apply absolute z-50 top-4 left-4 px-8 py-4 rounded-lg bg-oxford-200 border-2 border-oxford-700 font-semibold text-oxford-800 hover:bg-oxford-50 hover:text-oxford-900 hover:border-oxford-600 focus:bg-oxford-50 focus:text-oxford-900 focus:border-oxford-600;
+}
+
 .ie11 {
   .gap-y-8 > div + div {
     margin-top: 1rem;

--- a/assets/src/styles/main.scss
+++ b/assets/src/styles/main.scss
@@ -53,7 +53,7 @@ html {
   @apply m-0 p-0 list-none bg-oxford-50 pt-14 pb-4 px-5 rounded-lg relative overflow-hidden;
 
   &::before {
-    @apply absolute top-0 left-0 z-50 w-auto h-auto py-2 px-4 bg-oxford-900 text-white rounded-br-md font-semibold text-lg;
+    @apply absolute top-0 left-0 z-10 w-auto h-auto py-2 px-4 bg-oxford-900 text-white rounded-br-md font-semibold text-lg;
     content: "Menu";
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tailwindcss/forms": "^0.3.4",
         "@tailwindcss/typography": "^0.4.1",
+        "alpine-magic-helpers": "^1.2.2",
         "alpinejs": "^2.8.2",
         "tailwindcss": "^2.2.19"
       },
@@ -275,6 +276,14 @@
       "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
+    },
+    "node_modules/alpine-magic-helpers": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/alpine-magic-helpers/-/alpine-magic-helpers-1.2.2.tgz",
+      "integrity": "sha512-eOEpIV22Qrp3R1Y3PO1ku1bishB5rDVlW9jcCfIwytmu//F7OirpBdGTgrQwPHQz3RWdy4+EEBJHnNs7CZVjaQ==",
+      "peerDependencies": {
+        "alpinejs": "^2.8"
+      }
     },
     "node_modules/alpinejs": {
       "version": "2.8.2",
@@ -3015,6 +3024,12 @@
       "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
+    },
+    "alpine-magic-helpers": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/alpine-magic-helpers/-/alpine-magic-helpers-1.2.2.tgz",
+      "integrity": "sha512-eOEpIV22Qrp3R1Y3PO1ku1bishB5rDVlW9jcCfIwytmu//F7OirpBdGTgrQwPHQz3RWdy4+EEBJHnNs7CZVjaQ==",
+      "requires": {}
     },
     "alpinejs": {
       "version": "2.8.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@tailwindcss/forms": "^0.3.4",
     "@tailwindcss/typography": "^0.4.1",
+    "alpine-magic-helpers": "^1.2.2",
     "alpinejs": "^2.8.2",
     "tailwindcss": "^2.2.19"
   }

--- a/templates/base.html
+++ b/templates/base.html
@@ -32,25 +32,22 @@
   <link rel="apple-touch-icon" href="{% static 'apple-touch-icon.png' %}">
   <link rel="manifest" href="{% static 'manifest.webmanifest' %}">
 </head>
-<body class="lg:overflow-y-hidden">
+<body class="flex flex-nowrap" :class="!$screen('lg') && isSidebarVisible ? 'overflow-y-hidden' : 'overflow-y-scroll'">
   <a id="skip-link" href="#content" class="sr-only focus:not-sr-only">
     Skip to content
   </a>
-  <div class="pt-12 lg:pt-0 lg:h-screen flex overflow-hidden bg-white">
-    {% include "partials/sidebar.html" %}
 
-    <div class="ie-block flex flex-col w-0 flex-1 overflow-hidden">
-      {% include "partials/header.html" %}
+  {% include "partials/sidebar.html" %}
 
-      <div class="flex flex-col flex-1 relative lg:overflow-y-auto overflow-x-hidden">
-        <main class="flex-auto flex-shrink-0 pt-6 pb-16 bg-gray-50" id="content">
-          {% include "partials/alert.html" %}
-          {% block content %}{% endblock content %}
-        </main>
+  <div class="w-full flex-1 pt-16 lg:pt-0 bg-gray-50">
+    {% include "partials/header.html" %}
 
-        {% include 'partials/footer.html' %}
-      </div>
-    </div>
+    <main class="min-h-screen ie-block" id="content">
+      {% include "partials/alert.html" %}
+      {% block content %}{% endblock content %}
+    </main>
+
+    {% include 'partials/footer.html' %}
   </div>
 
   {# Legacy browsers #}

--- a/templates/base.html
+++ b/templates/base.html
@@ -32,6 +32,9 @@
   <link rel="manifest" href="{% static 'manifest.webmanifest' %}">
 </head>
 <body class="lg:overflow-y-hidden">
+  <a id="skip-link" href="#content" class="sr-only focus:not-sr-only">
+    Skip to content
+  </a>
   <div class="pt-12 lg:pt-0 lg:h-screen flex overflow-hidden bg-white">
     {% include "partials/sidebar.html" %}
 
@@ -39,7 +42,7 @@
       {% include "partials/header.html" %}
 
       <div class="flex flex-col flex-1 relative lg:overflow-y-auto overflow-x-hidden">
-        <main class="flex-auto flex-shrink-0 pt-6 pb-16 bg-gray-50">
+        <main class="flex-auto flex-shrink-0 pt-6 pb-16 bg-gray-50" id="content">
           {% include "partials/alert.html" %}
           {% block content %}{% endblock content %}
         </main>

--- a/templates/base.html
+++ b/templates/base.html
@@ -19,7 +19,8 @@
   {% vite_hmr_client %}
 
   {# Modern browsers #}
-  <script async defer type="module" src="{% static 'vendor/alpine.js' %}"></script>
+  <script defer type="module" src="{% static 'vendor/alpine-magic-helpers/screen.js' %}"></script>
+  <script defer type="module" src="{% static 'vendor/alpine.js' %}"></script>
   {% vite_asset 'assets/src/scripts/main.js' %}
 
   {% block extra_head %}{% endblock %}

--- a/templates/partials/sidebar.html
+++ b/templates/partials/sidebar.html
@@ -1,10 +1,10 @@
 {% load reports_tags %}
 
-<div class="fixed inset-0 z-40 lg:relative lg:flex w-64 lg:bg-oxford-800" x-show="$screen('lg') || isSidebarVisible">
+<header class="fixed inset-0 z-30 lg:relative lg:flex w-64 lg:bg-oxford-800" x-show="$screen('lg') || isSidebarVisible">
   <div
     @click="isSidebarVisible = false"
     aria-hidden="true"
-    class="fixed inset-0 z-0 bg-gray-600 bg-opacity-75"
+    class="fixed inset-0 z-20 bg-gray-600 bg-opacity-75"
     x-cloak
     x-show="!$screen('lg') && isSidebarVisible"
     x-transition:enter-end="opacity-100"
@@ -32,7 +32,7 @@
     </button>
   </div>
   <div
-    class="fixed h-screen overflow-y-scroll w-64 z-10 bg-oxford-800"
+    class="fixed h-screen overflow-y-scroll w-64 z-40 bg-oxford-800"
     x-show="$screen('lg') || isSidebarVisible"
     x-transition:enter-end="translate-x-0"
     x-transition:enter-start="-translate-x-full"
@@ -105,4 +105,4 @@
       </div>
     </nav>
   </div>
-</div>
+</header>

--- a/templates/partials/sidebar.html
+++ b/templates/partials/sidebar.html
@@ -1,181 +1,108 @@
 {% load reports_tags %}
 
-{# Mobile sidebar #}
-<div
-  aria-modal="true"
-  class="fixed inset-0 flex z-40 lg:hidden"
-  x-cloak
-  x-ref="dialog"
-  x-show="isSidebarVisible">
+<div class="fixed inset-0 z-40 lg:relative lg:flex w-64 lg:bg-oxford-800" x-show="$screen('lg') || isSidebarVisible">
   <div
     @click="isSidebarVisible = false"
     aria-hidden="true"
-    class="fixed inset-0 bg-gray-600 bg-opacity-75"
+    class="fixed inset-0 z-0 bg-gray-600 bg-opacity-75"
     x-cloak
-    x-show="isSidebarVisible"
+    x-show="!$screen('lg') && isSidebarVisible"
     x-transition:enter-end="opacity-100"
     x-transition:enter-start="opacity-0"
     x-transition:enter="transition-opacity ease-linear duration-300"
     x-transition:leave-end="opacity-0"
     x-transition:leave-start="opacity-100"
-    x-transition:leave="transition-opacity ease-linear duration-300"></div>
-    <div
-      class="relative flex-1 flex flex-col max-w-xs w-full pb-4 bg-oxford-800"
-      x-cloak
-      x-show="isSidebarVisible"
-      x-transition:enter-end="translate-x-0"
-      x-transition:enter-start="-translate-x-full"
-      x-transition:enter="transition ease-in-out duration-300 transform"
-      x-transition:leave-end="-translate-x-full"
-      x-transition:leave-start="translate-x-0"
-      x-transition:leave="transition ease-in-out duration-300 transform">
-      <div
-        class="absolute top-0 right-0 -mr-12 pt-2"
-        x-cloak
-        x-show="isSidebarVisible"
-        x-transition:enter-end="opacity-100"
-        x-transition:enter-start="opacity-0"
-        x-transition:enter="ease-in-out duration-300"
-        x-transition:leave-end="opacity-0"
-        x-transition:leave-start="opacity-100"
-        x-transition:leave="ease-in-out duration-300">
-        <button type="button" @click="isSidebarVisible = false" class="ml-1 flex items-center justify-center h-10 w-10 rounded-full focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white">
-          <span class="sr-only">Close sidebar</span>
-          {% include "icons/outline/x.svg" with htmlClass="h-6 w-6 text-white" attrs="aria-hidden='true'" %}
-        </button>
+    x-transition:leave="transition-opacity ease-linear duration-300"
+    ></div>
+  {# Mobile-only: Close button #}
+  <div
+    class="absolute top-0 -right-12 z-50 pt-2 lg:hidden"
+    x-cloak
+    x-show="isSidebarVisible"
+    x-transition:enter-end="opacity-100"
+    x-transition:enter-start="opacity-0"
+    x-transition:enter="ease-in-out duration-300"
+    x-transition:leave-end="opacity-0"
+    x-transition:leave-start="opacity-100"
+    x-transition:leave="ease-in-out duration-300"
+  >
+    <button type="button" @click="isSidebarVisible = false" class="ml-1 flex items-center justify-center h-10 w-10 rounded-full focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white">
+      <span class="sr-only">Close sidebar</span>
+      {% include "icons/outline/x.svg" with htmlClass="h-6 w-6 text-white" attrs="aria-hidden='true'" %}
+    </button>
+  </div>
+  <div
+    class="fixed h-screen overflow-y-scroll w-64 z-10 bg-oxford-800"
+    x-show="$screen('lg') || isSidebarVisible"
+    x-transition:enter-end="translate-x-0"
+    x-transition:enter-start="-translate-x-full"
+    x-transition:enter="transition ease-in-out duration-300 transform"
+    x-transition:leave-end="-translate-x-full"
+    x-transition:leave-start="translate-x-0"
+    x-transition:leave="transition ease-in-out duration-300 transform"
+  >
+    <div class="flex items-center h-16 flex-shrink-0 px-4 bg-oxford-900">
+      <span class="text-xl text-white font-semibold">OpenSAFELY</span>
+    </div>
+    <nav class="flex-1 px-2 py-4 bg-oxford-800">
+      <div class="space-y-1">
+        <a href="/" class="text-white group flex items-center px-2 py-2 text-sm font-medium rounded-md hover:bg-oxford-900">
+          {% include "icons/outline/home.svg" with htmlClass="text-gray-300 mr-3 flex-shrink-0 h-6 w-6" %}
+          Home
+        </a>
+        <a href="mailto:team@opensafely.org" class="text-white group flex items-center px-2 py-2 text-sm font-medium rounded-md hover:bg-oxford-900">
+          {% include "icons/outline/mail-open.svg" with htmlClass="text-gray-300 mr-3 flex-shrink-0 h-6 w-6" %}
+          Contact
+        </a>
       </div>
-      <div class="flex items-center h-16 flex-shrink-0 px-4 bg-oxford-900">
-        <span class="text-xl text-white font-semibold">OpenSAFELY</span>
-      </div>
-      <div class="mt-5 flex-1 h-0 overflow-y-auto">
-        <nav class="flex-1 px-2 py-4 bg-oxford-800">
-          <div class="space-y-1">
-            <a href="/" class="text-white group flex items-center px-2 py-2 text-sm font-medium rounded-md hover:bg-oxford-900 hover:text-gray-50">
-              {% include "icons/outline/home.svg" with htmlClass="text-gray-300 mr-3 flex-shrink-0 h-6 w-6" %}
-              Home
-            </a>
-            <a href="mailto:team@opensafely.org" class="text-white group flex items-center px-2 py-2 text-sm font-medium rounded-md hover:bg-oxford-900 hover:text-gray-50 ">
-              {% include "icons/outline/mail-open.svg" with htmlClass="text-gray-300 mr-3 flex-shrink-0 h-6 w-6" %}
-              Contact
-            </a>
-          </div>
-          <div class="mt-10">
-            <p class="px-3 text-xs font-semibold text-gray-400 uppercase tracking-wider">
-              Reports
-            </p>
-            <div class="mt-2 space-y-1">
-              <nav class="flex-1 px-2 space-y-1 bg-oxford-800" aria-label="Sidebar">
-                <ul>
-                  {% for category in categories %}
-                    <li x-data="{ isSubmenuOpen: {% if report.category.id == category.id %}true{% else %}false{% endif %} }" class="space-y-1">
-                      <button
-                        @click="isSubmenuOpen = !isSubmenuOpen"
-                        aria-controls="mobile-sidebar-{{ forloop.counter }}"
-                        aria-expanded="false"
-                        class="text-white hover:bg-oxford-900 hover:text-gray-50 group w-full flex items-center pr-2 py-2 text-left text-sm font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-oxford-400"
-                        type="button"
-                        x-bind:aria-expanded="isSubmenuOpen.toString()">
-                        {% include "icons/outline/chevron-right.svg" with htmlClass="text-gray-300 mr-2 flex-shrink-0 h-5 w-5 transform group-hover:text-gray-400 transition-colors ease-in-out duration-150" attrs=":class=\"{ 'text-gray-400 rotate-90': isSubmenuOpen, 'text-gray-300': !(isSubmenuOpen) }\"" %}
-                        {{ category.name }}
-                      </button>
-                      <ul
-                        class="space-y-1"
-                        id="mobile-sidebar-{{ forloop.counter }}"
-                        x-cloak
-                        x-show="isSubmenuOpen">
-                        {% category_reports_for_user category as category_reports %}
-                        {% for single_report in category_reports %}
-                          <li>
-                            <a href="{{ single_report.get_absolute_url }}" class="group w-full flex items-center pl-10 pr-2 py-2 text-sm font-medium text-white hover:bg-oxford-900 hover:text-gray-50 rounded-md
-                              {% if single_report.id == report.id %}
-                                bg-oxford-700
-                              {% endif %}
-                            ">
-                              {{ single_report.menu_name }} {% if single_report.is_draft %}(Draft){% endif %}
-                            </a>
-                          </li>
-                        {% endfor %}
-                      </ul>
-                    </li>
+      <div class="mt-10">
+        <h2 class="px-3 text-xs font-semibold text-gray-400 uppercase tracking-wider">
+          Reports
+        </h2>
+        <div class="mt-2 space-y-1">
+          <nav class="flex-1 px-2 space-y-1 bg-oxford-800" aria-label="Sidebar">
+            <ul>
+              {% for category in categories %}
+              <li x-data="{ isSubmenuVisible: {% if report.category.id == category.id %}true{% else %}false{% endif %} }" class="space-y-1">
+                <button
+                  @click="isSubmenuVisible = !isSubmenuVisible"
+                  aria-controls="desktop-sidebar-{{ forloop.counter }}"
+                  aria-expanded="false"
+                  class="text-white hover:bg-oxford-900 hover:text-gray-50 group w-full flex items-center pr-2 py-2 text-left text-sm font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-oxford-400"
+                  type="button"
+                  x-bind:aria-expanded="isSubmenuVisible.toString()"
+                >
+                  {% include "icons/outline/chevron-right.svg" with htmlClass="text-gray-300 mr-2 flex-shrink-0 h-5 w-5 transform group-hover:text-gray-400 transition-colors ease-in-out duration-150" attrs=":class=\"{ 'text-gray-400 rotate-90': isSubmenuVisible, 'text-gray-300': !(isSubmenuVisible) }\"" %}
+                  {{ category.name }}
+                </button>
+                <ul
+                  class="space-y-1"
+                  id="desktop-sidebar-{{ forloop.counter }}"
+                  x-show="isSubmenuVisible"
+                  x-cloak
+                >
+                  {% category_reports_for_user category as category_reports %}
+                  {% for single_report in category_reports %}
+                  <li>
+                    <a
+                      href="{{ single_report.get_absolute_url }}"
+                      class="
+                        group w-full flex items-center pl-8 pr-2 py-2 text-sm font-medium text-white hover:bg-oxford-900 hover:text-gray-50 rounded-md
+                        {% if single_report.id == report.id %}
+                          bg-oxford-700 bg-opacity-50
+                        {% endif %}
+                      ">
+                      {{ single_report.menu_name }} {% if single_report.is_draft %}(Draft){% endif %}
+                    </a>
+                  </li>
                   {% endfor %}
                 </ul>
-              </nav>
-            </div>
-          </div>
-        </nav>
-      </div>
-    </div>
-    <div class="flex-shrink-0 w-14" aria-hidden="true"><!-- Dummy element to force sidebar to shrink to fit close icon -->
-  </div>
-</div>
-
-{# Desktop sidebar #}
-<div class="hidden lg:flex lg:flex-shrink-0">
-  <div class="flex flex-col w-64">
-    <div class="flex flex-col h-0 flex-1">
-      <div class="flex items-center h-16 flex-shrink-0 px-4 bg-oxford-900">
-        <span class="text-xl text-white font-semibold">OpenSAFELY</span>
-      </div>
-      <div class="flex-1 flex flex-col overflow-y-auto">
-        <nav class="flex-1 px-2 py-4 bg-oxford-800">
-          <div class="space-y-1">
-            <a href="/" class="text-white group flex items-center px-2 py-2 text-sm font-medium rounded-md hover:bg-oxford-900">
-              {% include "icons/outline/home.svg" with htmlClass="text-gray-300 mr-3 flex-shrink-0 h-6 w-6" %}
-              Home
-            </a>
-            <a href="mailto:team@opensafely.org" class="text-white group flex items-center px-2 py-2 text-sm font-medium rounded-md hover:bg-oxford-900">
-              {% include "icons/outline/mail-open.svg" with htmlClass="text-gray-300 mr-3 flex-shrink-0 h-6 w-6" %}
-              Contact
-            </a>
-          </div>
-          <div class="mt-10">
-            <h2 class="px-3 text-xs font-semibold text-gray-400 uppercase tracking-wider">
-              Reports
-            </h2>
-            <div class="mt-2 space-y-1">
-              <nav class="flex-1 px-2 space-y-1 bg-oxford-800" aria-label="Sidebar">
-                  <ul>
-                    {% for category in categories %}
-                      <li x-data="{ isSubmenuOpen: {% if report.category.id == category.id %}true{% else %}false{% endif %} }" class="space-y-1">
-                        <button
-                          @click="isSubmenuOpen = !isSubmenuOpen"
-                          aria-controls="desktop-sidebar-{{ forloop.counter }}"
-                          aria-expanded="false"
-                          class="text-white hover:bg-oxford-900 hover:text-gray-50 group w-full flex items-center pr-2 py-2 text-left text-sm font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-oxford-400"
-                          type="button"
-                          x-bind:aria-expanded="isSubmenuOpen.toString()">
-                          {% include "icons/outline/chevron-right.svg" with htmlClass="text-gray-300 mr-2 flex-shrink-0 h-5 w-5 transform group-hover:text-gray-400 transition-colors ease-in-out duration-150" attrs=":class=\"{ 'text-gray-400 rotate-90': isSubmenuOpen, 'text-gray-300': !(isSubmenuOpen) }\"" %}
-                          {{ category.name }}
-                        </button>
-                        <ul
-                          class="space-y-1"
-                          id="desktop-sidebar-{{ forloop.counter }}"
-                          x-show="isSubmenuOpen"
-                          x-cloak>
-                            {% category_reports_for_user category as category_reports %}
-                            {% for single_report in category_reports %}
-                              <li>
-                                <a
-                                  href="{{ single_report.get_absolute_url }}"
-                                  class="
-                                    group w-full flex items-center pl-8 pr-2 py-2 text-sm font-medium text-white hover:bg-oxford-900 hover:text-gray-50 rounded-md
-                                    {% if single_report.id == report.id %}
-                                      bg-oxford-700 bg-opacity-50
-                                    {% endif %}
-                                  ">
-                                  {{ single_report.menu_name }} {% if single_report.is_draft %}(Draft){% endif %}
-                                </a>
-                              </li>
-                            {% endfor %}
-                        </ul>
-                      </li>
-                    {% endfor %}
-                  </ul>
-                </nav>
-              </div>
-            </div>
+              </li>
+              {% endfor %}
+            </ul>
           </nav>
         </div>
       </div>
-    </div>
+    </nav>
   </div>
+</div>

--- a/vite.config.js
+++ b/vite.config.js
@@ -29,6 +29,10 @@ const config = {
           src: "./node_modules/alpinejs/dist/*",
           dest: "./assets/dist/vendor",
         },
+        {
+          src: "./node_modules/alpine-magic-helpers/dist/*",
+          dest: "./assets/dist/vendor/alpine-magic-helpers",
+        },
       ],
       hook: "writeBundle",
     }),


### PR DESCRIPTION
This update rewrites the UI to stop using overflow scrolling and instead builds the UI with flexbox. Thanks to this change we can also make a number of smaller UI tweaks listed below.

Closes https://github.com/opensafely-core/output-explorer/issues/227

## Skiplink

Add an a11y skip link

https://user-images.githubusercontent.com/24863179/148763855-8dcdc06e-1464-4c7b-b869-9fbf0e990879.mov

## New navigation

Previously the mobile and desktop navs were separate, this updates them to use a single nav which changes its visual appearance based on the screen size. AlpineJS magic helpers have been added to change the state based on screen size.

### Example

Screenshots of the difference (with styling disabled).

#### Before

<img width="408" alt="new-navigation-before" src="https://user-images.githubusercontent.com/24863179/148763844-7f7001db-b08d-4ed8-ba75-b17f4c2531e3.png">

#### After

<img width="380" alt="new-navigation-after" src="https://user-images.githubusercontent.com/24863179/148763828-4ce04d64-2d91-46cf-9561-0188b1bb2bf3.png">

## Smooth scrolling

Added smooth scrolling to anchor links (not available in Safari)

https://user-images.githubusercontent.com/24863179/148763793-bc2050cb-8723-4f14-9c16-2e20e99ccd09.mov
