### PR TITLE
Ensure that user-facing report metadata is up to date

### DIFF
--- a/reports/models.py
+++ b/reports/models.py
@@ -143,6 +143,7 @@ class Report(models.Model):
         null=True,
         blank=True,
         help_text="File last modified date; autopopulated from GitHub",
+        verbose_name="Last released",
     )
     cache_token = models.UUIDField(default=uuid4)
     # Flag to remember if this report needed to use the git blob method (see github.py),

--- a/reports/templates/reports/report.html
+++ b/reports/templates/reports/report.html
@@ -67,7 +67,7 @@
             </div>
             <div class="flex sm:inline-flex flex-col sm:ml-16">
               <dt class="mb-1 font-semibold">
-                Last updated
+                Last released
               </dt>
               <dd class="mb-4">
                 {{ report.last_updated|date:"d M Y"}}

--- a/reports/templates/reports/report.html
+++ b/reports/templates/reports/report.html
@@ -70,7 +70,7 @@
                 Last released
               </dt>
               <dd class="mb-4">
-                {{ report.last_updated|date:"d M Y"}}
+                {{ github_report.last_updated|date:"d M Y"}}
               </dd>
             </div>
 

--- a/tests/reports/test_github.py
+++ b/tests/reports/test_github.py
@@ -144,7 +144,14 @@ def test_get_large_html_from_github(httpretty):
     # get_contents is called twice, once on the single file, once for the parent folder contents
     assert report.use_git_blob is True
 
-    # # re-fetch; get_contents is not called again on the single file, only on the parent folder
+    # refetch; the html has now been stored on the GithubReport, so no additional calls are made
+    assert github_report.get_html() == html
+    latest_requests = httpretty.latest_requests()
+    assert len(latest_requests) == 4
+
+    # instantiate a new GithubReport and re-fetch; get_contents is not called again on the single file,
+    # only on the parent folder
+    github_report = GithubReport(report, repo=repo)
     assert github_report.get_html() == html
     # Only 3 more calls, to /contents for the parent folder, /git/blob for the file contents
     # and /commits for the update date

--- a/tests/reports/test_views.py
+++ b/tests/reports/test_views.py
@@ -360,6 +360,25 @@ def test_report_view_cache(client, log_output):
 
 
 @pytest.mark.django_db
+def test_report_view_last_updated(client, log_output):
+    """
+    Test that the last updated field (which is fetched on page load and stored on the
+    model) is displayed properly on the report page.
+    """
+    report = baker.make_recipe("reports.real_report")
+    assert report.last_updated is None
+
+    # fetch report
+    response = client.get(report.get_absolute_url())
+    assert response.status_code == 200
+
+    report.refresh_from_db()
+    assert report.last_updated is not None
+
+    assert report.last_updated.strftime("%d %b %Y") in response.rendered_content
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     "html",
     [


### PR DESCRIPTION
Fixes #195 

Most of the report metadata is kept up to date by updating a cache token whenever changes are made in the report's admin page.  This works for everything except the `last_updated` field, because this field is fetched from GitHub.  For a new or updated report, the report content is fetched again from GitHub, which updates the `last_updated` field on the model instance.  However, this was being done in the template _after_ the `last_update` field had been rendered, so the refreshed value wasn't making it into the page.

This PR adds a new method to the `GithubReport` so that the template can use `{[ github_report.last_updated }}` which does the fetching of the report content from github rather than just displaying the current value on the report instance.  It stores the fetched content so that it's still only fetched once for an updated report.

Also change "last updated" to "last released" in the UI (Fixes #159)