### PR TITLE
Update prose styling

### DIFF
--- a/assets/src/styles/main.scss
+++ b/assets/src/styles/main.scss
@@ -91,4 +91,47 @@ details {
     }
   }
 }
+
+/**
+ * Oxford Prose
+ */
+.prose-oxford {
+  @apply text-gray-800;
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @apply text-gray-800;
+  }
+
+  ul > li::before {
+    @apply bg-gray-800;
+  }
+
+  pre {
+    @apply bg-gray-50 text-gray-700;
+  }
+
+  thead th {
+    @apply text-left;
+  }
+
+  code::before,
+  code::after {
+    content: "";
+  }
+
+  a,
+  a strong {
+    @apply text-oxford-600 font-semibold;
+  }
+
+  a:hover,
+  a:hover strong {
+    @apply text-oxford underline;
+  }
+}
 /*! purgecss end ignore */

--- a/assets/src/styles/notebook.scss
+++ b/assets/src/styles/notebook.scss
@@ -101,13 +101,4 @@ details {
     }
   }
 }
-
-// Fix strong links in prose sections
-.prose-oxford a strong {
-  @apply text-oxford-600;
-}
-
-.prose-oxford a:hover strong {
-  @apply text-oxford underline;
-}
 /*! purgecss end ignore */

--- a/assets/src/styles/notebook.scss
+++ b/assets/src/styles/notebook.scss
@@ -102,4 +102,12 @@ details {
   }
 }
 
+// Fix strong links in prose sections
+.prose-oxford a strong {
+  @apply text-oxford-600;
+}
+
+.prose-oxford a:hover strong {
+  @apply text-oxford underline;
+}
 /*! purgecss end ignore */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -20,39 +20,6 @@ module.exports = {
       fontFamily: {
         sans: ["Public Sans", ...defaultTheme.fontFamily.sans],
       },
-      typography: (theme) => ({
-        DEFAULT: {
-          css: {
-            color: theme("colors.gray.800"),
-            "h1, h2, h3, h4, h5, h6": {
-              color: theme("colors.gray.800"),
-            },
-            "ul > li::before": {
-              "background-color": theme("colors.gray.800"),
-            },
-            pre: {
-              "background-color": theme("colors.gray.50"),
-              color: theme("colors.gray.700"),
-            },
-            "thead th": {
-              "text-align": "left",
-            },
-            a: {
-              "font-weight": 600,
-            },
-            "a:hover": {
-              color: theme("colors.oxford.800"),
-              "text-decoration": "underline",
-            },
-            "code::before": {
-              content: "",
-            },
-            "code::after": {
-              content: "",
-            },
-          },
-        },
-      }),
       colors: {
         oxford: {
           DEFAULT: "#002147",


### PR DESCRIPTION
## Fix strong tags in links

Given the following code:

```html
<li><a href="#Cumulative-third-dose-vaccination-figures-among-80+-population"><strong>80+</strong> population</a></li>
```

Example: https://reports.opensafely.org/reports/vaccine-coverage-thirdbooster-doses/#Contents

### Before

https://user-images.githubusercontent.com/24863179/158556957-68b703f9-7828-4051-89ae-0949994068da.mp4

### After

https://user-images.githubusercontent.com/24863179/158557006-5c0ca3e0-4792-4da6-9379-7e408e275555.mp4

## Move typography styles to stylesheet

Migrate styles from the `tailwind.config.js` file to `@apply` styles in `main.scss`