### PR TITLE
Update dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 21.6b0
+    rev: 22.1.0
     hooks:
     - id: black
       language_version: python3.10

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,9 +13,7 @@ repos:
       additional_dependencies:
       - "flake8-builtins"
       - "flake8-no-pep420"
-      # skipping flake8-implicit-str-concat due to conflict in attrs version
-      # Should be fixed in next version, see https://github.com/keisheiled/flake8-implicit-str-concat/pull/31
-      # - "flake8-implicit-str-concat"
+      - "flake8-implicit-str-concat"
 
   - repo: https://github.com/pycqa/isort
     rev: 5.10.1

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -6,6 +6,7 @@
 black
 flake8
 flake8-builtins
+flake8-implicit-str-concat
 flake8-no-pep420
 httpretty
 ipdb

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -4,6 +4,10 @@
 #
 #    pip-compile --allow-unsafe --generate-hashes --output-file=requirements.dev.txt requirements.dev.in
 #
+appnope==0.1.3 \
+    --hash=sha256:02bd91c4de869fbb1e1c50aafc4098827a7a54ab2f39d9dcba6c9547ed920e24 \
+    --hash=sha256:265a455292d0bd8a72453494fa24df5a11eb18373a60c7c0430889f22548605e
+    # via ipython
 asgiref==3.5.0 \
     --hash=sha256:2f8abc20f7248433085eda803936d98992f1343ddb022065779f37c5da0181d0 \
     --hash=sha256:88d59c13d634dcffe0510be048210188edd79aeccb6a6c9028cdad6f31d730a9

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -19,6 +19,7 @@ attrs==21.4.0 \
     --hash=sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd
     # via
     #   -c requirements.prod.txt
+    #   flake8-implicit-str-concat
     #   pytest
 backcall==0.2.0 \
     --hash=sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e \
@@ -137,6 +138,10 @@ flake8-builtins==1.5.3 \
     --hash=sha256:09998853b2405e98e61d2ff3027c47033adbdc17f9fe44ca58443d876eb00f3b \
     --hash=sha256:7706babee43879320376861897e5d1468e396a40b8918ed7bccf70e5f90b8687
     # via -r requirements.dev.in
+flake8-implicit-str-concat==0.3.0 \
+    --hash=sha256:a89ebc50567790fb7b83e032ed4014ae0db70e35d89e269c3323967135023600 \
+    --hash=sha256:c0e6ae227e46238e4c87844091f8072892caeccd3bb266576a7d449eadbf53a0
+    # via -r requirements.dev.in
 flake8-no-pep420==2.2.0 \
     --hash=sha256:a1622f03be67609b81a9e6790e7e69c310eb6fbd7bb81817f7fb91902312bc76 \
     --hash=sha256:a280a840f84682f683b33b348ad8d3434309b544c142be539f168e13cc16abea
@@ -179,6 +184,10 @@ model-bakery==1.4.0 \
     --hash=sha256:a89befaae667380f5e2352981d45fed36747941f5c3e9dffa962fc6ba8d661d1 \
     --hash=sha256:c29fb821c81cda2c37dfbdcb1dd2218cda179ecb96c6edb6cd9cdaa146706d92
     # via -r requirements.dev.in
+more-itertools==8.12.0 \
+    --hash=sha256:43e6dd9942dffd72661a2c4ef383ad7da1e6a3e968a927ad7a6083ab410a688b \
+    --hash=sha256:7dc6ad46f05f545f900dd59e8dfb4e84a4827b97b3cfecb175ea0c7d247f6064
+    # via flake8-implicit-str-concat
 mypy-extensions==0.4.3 \
     --hash=sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d \
     --hash=sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8


### PR DESCRIPTION
This is a collection of dependency fixes:
* black to skip the the click/_unicodefun issue and match what dev requirements have pinned
* re-enable flake8-implict-str-concat, the fixed version has been released
* add appnope to requirements so non-docker installs are possible on macOS