### PR TITLE
Use correct package name for pytest wrapper of coverage.py

### DIFF
--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -14,7 +14,7 @@ isort
 model-bakery
 pip-tools
 pre-commit
-pytest-coverage
+pytest-cov
 pytest-django
 pytest-env
 pytest-mock

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -285,14 +285,6 @@ pytest==7.0.1 \
 pytest-cov==3.0.0 \
     --hash=sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6 \
     --hash=sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470
-    # via pytest-cover
-pytest-cover==3.0.0 \
-    --hash=sha256:578249955eb3b5f3991209df6e532bb770b647743b7392d3d97698dc02f39ebb \
-    --hash=sha256:5bdb6c1cc3dd75583bb7bc2c57f5e1034a1bfcb79d27c71aceb0b16af981dbf4
-    # via pytest-coverage
-pytest-coverage==0.0 \
-    --hash=sha256:db6af2cbd7e458c7c9fd2b4207cee75258243c8a81cad31a7ee8cfad5be93c05 \
-    --hash=sha256:dedd084c5e74d8e669355325916dc011539b190355021b037242514dee546368
     # via -r requirements.dev.in
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
@@ -367,6 +359,7 @@ tomli==2.0.1 \
     --hash=sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f
     # via
     #   black
+    #   coverage
     #   pep517
     #   pytest
 traitlets==5.1.1 \


### PR DESCRIPTION
pytest-coverage does eventually resolve to pytest-cov, but is a
placeholder package.