### PR TITLE
fix: only refresh the HTTP cache if report contents are on GitHub

### DIFF
--- a/reports/job_server.py
+++ b/reports/job_server.py
@@ -80,6 +80,11 @@ class JobServerReport:
         self.report = report
         self._fetched_html = None
 
+    def clear_cache(self):
+        """Clear the cache for the Report's job-server URL"""
+        if hasattr(self.client.session, "cache"):
+            self.client.session.cache.delete_url(self.report.job_server_url)
+
     def file_exists(self):
         return self.client.file_exists(self.report.job_server_url)
 

--- a/reports/models.py
+++ b/reports/models.py
@@ -177,10 +177,18 @@ class Report(models.Model):
         return self.slug
 
     def refresh_cache_token(self, refresh_http_cache=True, commit=True):
-        """Refresh cache token to invalidate http cache and clear request cache for github requests related to this repo"""
+        """
+        Refresh cache token to invalidate http cache and clear request cache
+        for hosting requests related to this repo
+        """
         self.cache_token = uuid4()
+
         if refresh_http_cache:
-            GithubReport(self).repo.clear_cache()
+            if self.uses_github:
+                GithubReport(self).repo.clear_cache()
+            else:
+                JobServerReport(self).clear_cache()
+
         if commit:
             self.save()
 


### PR DESCRIPTION
Fixes:
* https://sentry.io/organizations/ebm-datalab/issues/3270767930/?project=5756541
* https://sentry.io/organizations/ebm-datalab/issues/3270767274/?project=5756541