### PR TITLE
Move Currency Lock into `deploy` Job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,8 +11,6 @@ on:
   push:
   workflow_dispatch:
 
-concurrency: ci-${{ github.ref }}
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -126,6 +124,8 @@ jobs:
       packages: write
 
     if: github.ref == 'refs/heads/main'
+
+    concurrency: deploy-production
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
A workflow-level lock using the git ref means a flurry of merges will cancel all but the latest workflow.  Any potential breakages from one merge will be harder to track down because they will only show up in the latest merge.

I'm reasonably sure this is the behaviour we want from the concurrency lock.  It means we run more workflows, but creates fewer notifications for users (every cancelled workflow notifies at least the merger), and should make tracking down a broken merge easier as the first failed workflow _should_ point to the offending merge.