### PR TITLE
s/output-explorer/reports/g

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -96,13 +96,13 @@ RUN --mount=type=cache,target=/root/.cache \
 #
 # Not including the code at this stage has two benefits:
 #
-# 1) this image only rebuilds when the handlful of files needed to build output-explorer-base
+# 1) this image only rebuilds when the handlful of files needed to build reports-base
 #    changes. If we do `COPY . /app` now, this will rebuild when *any* file changes.
 #
 # 2) Ensures we *have* to mount the volume for dev image, as there's no embedded
 #    version of the code. Otherwise, we could end up accidentally using the
 #    version of the code included when the prod image was built.
-FROM base-python as output-explorer-base
+FROM base-python as reports-base
 
 # copy venv over from builder image. These will have root:root ownership, but
 # are readable by all.
@@ -123,13 +123,13 @@ ENV PYTHONPATH=/app
 # Production image
 #
 # Copy code in, add proper metadata
-FROM output-explorer-base as output-explorer-prod
+FROM reports-base as reports-prod
 
 # Adjust this metadata to fit project. Note that the base-docker image does set
 # some basic metadata.
-LABEL org.opencontainers.image.title="output-explorer" \
+LABEL org.opencontainers.image.title="reports" \
       org.opencontainers.image.description="Output Explorer" \
-      org.opencontainers.image.source="https://github.com/opensafely-core/output-explorer"
+      org.opencontainers.image.source="https://github.com/opensafely-core/reports"
 
 # copy application code
 COPY . /app
@@ -157,10 +157,10 @@ LABEL org.opencontainers.image.revision=$GITREF
 #
 # Dev image
 #
-# Now we build a dev image from our output-explorer-base image. This is basically
+# Now we build a dev image from our reports-base image. This is basically
 # installing dev dependencies and changing the entrypoint
 #
-FROM output-explorer-base as output-explorer-dev
+FROM reports-base as reports-dev
 
 # install development requirements
 COPY requirements.dev.txt /tmp/requirements.dev.txt

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -3,17 +3,17 @@
 services:
   prod:
     # image name, both locally and public
-    image: output-explorer
+    image: reports
     build:
       context: ..
       # path relative to context
       dockerfile: docker/Dockerfile
       # the prod stage in the Dockerfile
-      target: output-explorer-prod
+      target: reports-prod
       # should speed up the build in CI, where we have a cold cache
       cache_from:  # should speed up the build in CI, where we have a cold cache
         - ghcr.io/opensafely-core/base-docker
-        - ghcr.io/opensafely-core/output-explorer
+        - ghcr.io/opensafely-core/reports
       args:
         # this makes the image work for later cache_from: usage
         - BUILDKIT_INLINE_CACHE=1
@@ -28,7 +28,7 @@ services:
   node-assets:
     extends:
       service: prod
-    image: output-explorer-node-assets
+    image: reports-node-assets
     build:
       # the node-builder stage in the Dockerfile
       target: node-builder
@@ -39,11 +39,11 @@ services:
   dev:
     extends:
       service: prod
-    image: output-explorer-dev
-    container_name: output-explorer-dev
+    image: reports-dev
+    container_name: reports-dev
     build:
       # the dev stage in the Dockerfile
-      target: output-explorer-dev
+      target: reports-dev
     # paths relative to docker-compose.yaml file
     env_file:
       - ../.env
@@ -56,7 +56,7 @@ services:
   test:
     extends:
       service: dev
-    container_name: output-explorer-test
+    container_name: reports-test
     # different default test env
     env_file:
       - ../.test.env


### PR DESCRIPTION
The docker-compose config needs to point to the correct image and rather than have two names used across the docker config it seemed less surprising to keep the names in sync.