### PR TITLE
Use Plausible compat script for analytics

### DIFF
--- a/assets/src/scripts/_plausible.js
+++ b/assets/src/scripts/_plausible.js
@@ -1,24 +1,14 @@
 /**
  * Plausible Analytics only on production
- * Compat mode for IE11
  */
-if (document.location.hostname === "reports.opensafely.org") {
-  const ua = window.navigator.userAgent;
-  const trident = ua.indexOf("Trident/");
-  const msie = ua.indexOf("MSIE ");
+ var domain = "reports.opensafely.org";
 
-  const script = document.createElement("script");
-  script.defer = true;
-  script.setAttribute("data-domain", "reports.opensafely.org");
+ if (document.location.hostname === domain) {
+   var script = document.createElement("script");
+   script.defer = true;
+   script.setAttribute("data-domain", domain);
+   script.id = "plausible";
+   script.src = "https://plausible.io/js/plausible.compat.js";
 
-  // Serve legacy compat script to IE users
-  if (trident > 0 || msie > 0) {
-    script.id = "plausible";
-    script.src = "https://plausible.io/js/plausible.compat.js";
-  } else {
-    script.setAttribute("data-api", "/pa/api/event");
-    script.src = "/pa/js/script.js";
-  }
-
-  document.head.appendChild(script);
-}
+   document.head.appendChild(script);
+ }


### PR DESCRIPTION
So that we don't need to manually identify Internet Explorer users, and use Cloudflare Workers to serve the script.