### PR TITLE
Auto merge dependabot PRs using the central workflow

### DIFF
--- a/.github/workflows/auto-merge-dependabot-prs.yml
+++ b/.github/workflows/auto-merge-dependabot-prs.yml
@@ -1,0 +1,9 @@
+name: Auto merge Dependabot PRs
+
+on: pull_request
+
+jobs:
+  auto-merge-dependabot-prs:
+    uses: opensafely-core/.github/.github/workflows/auto-merge-dependabot-prs.yml@main
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This sets up auto-merging of Dependabot PRs using the workflow defined in [our .github repo](https://github.com/opensafely-core/.github).  I can't really test this without having this merged since only the dependabot user can trigger it.  

My plan is to get this merged then trigger a rebase on one of the pending PRs in this repo.

Ref opensafely-core/repo-template#68