### PR TITLE
Use setup-node v3+'s underlying cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,23 +20,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      # Node.js
-      - name: Cache node_modules
-        uses: actions/cache@v3.0.5
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
           node-version: "16"
+          cache: npm
 
       - name: Install node_modules
         run: npm ci


### PR DESCRIPTION
setup-node as of v3 uses actions/cache under the hood so we can make use
of that.  It knows to loop for package-lock.json by default.