### PR TITLE
Optimise dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -16,4 +16,4 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 20
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -13,7 +12,6 @@ updates:
       interval: "weekly"
     allow:
       - dependency-type: "production"
-    open-pull-requests-limit: 20
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "rebkwok"
     open-pull-requests-limit: 20
 
   - package-ecosystem: "npm"
@@ -15,8 +13,6 @@ updates:
       interval: "weekly"
     allow:
       - dependency-type: "production"
-    reviewers:
-      - "tomodwyer"
     open-pull-requests-limit: 20
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Now that we're auto-merging dependabots several parts of our config can go away or get updated since we don't have to worry about spamming humans.