### PR TITLE
Fix overflowing header on landing page

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -37,7 +37,7 @@
 
   {% include "partials/sidebar.html" %}
 
-  <div class="w-full flex-1 pt-16 lg:pt-0 bg-gray-50">
+  <div class="w-full flex-1 pt-16 lg:pt-0 bg-gray-50 overflow-x-hidden">
     {% include "partials/header.html" %}
 
     <main class="min-h-screen ie-block lg:mx-auto lg:max-w-screen-md xl:max-w-screen-lg" id="content">


### PR DESCRIPTION
The blue background on the homepage header is currently overflowing its container.