### PR TITLE
Add and style external report org information

### DIFF
--- a/templates/report.html
+++ b/templates/report.html
@@ -130,7 +130,7 @@
                 <img
                   alt="{{ report.org.name }} logo"
                   class="max-w-xs rounded overflow-hidden"
-                  src="/uploads/{{ report.org.logo }}"
+                  src="{{ report.org.logo.url }}"
                 >
                 <p class="text-center md:text-left">
                   <span>This is a report produced using the OpenSAFELY by:</span>


### PR DESCRIPTION
Closes #377 

## Example screenshot

<img width="1456" alt="CleanShot 2022-10-06 at 14 49 55@2x" src="https://user-images.githubusercontent.com/24863179/194330461-36ba7f8a-4b92-47b7-b267-edcd2ee7f444.png">