### PR TITLE
Switch to update-dependencies action for Python

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,6 @@
 version: 2
 
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "08:00"
-      timezone: "Europe/London"
-    open-pull-requests-limit: 20
-
   - package-ecosystem: "npm"
     directory: "/"
     schedule:

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,0 +1,30 @@
+name: Update python dependencies
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  "36 23 * * *"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - uses: "opensafely-core/setup-action@v1"
+      with:
+        python-version: "3.12"
+        install-just: true
+
+    - uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+      id: generate-token
+      with:
+        app-id: 1031449  # opensafely-core Create PR app
+        private-key: ${{ secrets.CREATE_PR_APP_PRIVATE_KEY }}
+
+    - uses: bennettoxford/update-dependencies-action@3db28281c78eeabfbe561c760c98aeddf8dfab30 # v1
+      with:
+        token: ${{ steps.generate-token.outputs.token }}

--- a/justfile
+++ b/justfile
@@ -120,6 +120,14 @@ upgrade env package="": virtualenv
     FORCE=true {{ just_executable() }} requirements-{{ env }} $opts
 
 
+# Upgrade all dev and prod dependencies.
+# This is the default input command to update-dependencies action
+# https://github.com/bennettoxford/update-dependencies-action
+update-dependencies:
+    just upgrade prod
+    just upgrade dev
+
+
 # *ARGS is variadic, 0 or more. This allows us to do `just test -k match`, for example.
 # Run the tests
 test *args: assets


### PR DESCRIPTION
In line with other `opensafely-core` repositories, and the current repo-template:

https://github.com/opensafely-core/repo-template/blob/4ec7ae0990573523c3eac47d7fad2e792a65cfbd/.github/workflows/update-dependencies.yml