### PR TITLE
Add cooldown for Dependabot GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,5 @@ updates:
       time: "08:00"
       timezone: "Europe/London"
     open-pull-requests-limit: 20
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
To match our dependency updates policy.