### PR TITLE
Pin `django` to 5.2 and revert, and `urllib3` update.

### DIFF
--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -3,7 +3,9 @@
 # To generate requirements file, run:
 # pip-compile --generate-hashes --output-file=requirements.prod.txt requirements.prod.in
 bs4
-django
+# The main Django web framework for building applications.
+# Pin to 5.2.x until we are happy with 6.0 compatibility.
+django>=5.2,<6.0
 django-csp
 django-extensions
 django-permissions-policy

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -260,9 +260,9 @@ dj-email-url==1.0.6 \
     --hash=sha256:55ffe3329e48f54f8a75aa36ece08f365e09d61f8a209773ef09a1d4760e699a \
     --hash=sha256:cbd08327fbb08b104eac160fb4703f375532e4c0243eb230f5b960daee7a96db
     # via environs
-django==6.0 \
-    --hash=sha256:1cc2c7344303bbfb7ba5070487c17f7fc0b7174bbb0a38cebf03c675f5f19b6d \
-    --hash=sha256:7b0c1f50c0759bbe6331c6a39c89ae022a84672674aeda908784617ef47d8e26
+django==5.2.9 \
+    --hash=sha256:16b5ccfc5e8c27e6c0561af551d2ea32852d7352c67d452ae3e76b4f6b2ca495 \
+    --hash=sha256:3a4ea88a70370557ab1930b332fd2887a9f48654261cdffda663fef5976bb00a
     # via
     #   -r requirements.prod.in
     #   dj-database-url
@@ -541,9 +541,9 @@ url-normalize==2.2.1 \
     --hash=sha256:3deb687587dc91f7b25c9ae5162ffc0f057ae85d22b1e15cf5698311247f567b \
     --hash=sha256:74a540a3b6eba1d95bdc610c24f2c0141639f3ba903501e61a52a8730247ff37
     # via requests-cache
-urllib3==2.6.1 \
-    --hash=sha256:5379eb6e1aba4088bae84f8242960017ec8d8e3decf30480b3a1abdaa9671a3f \
-    --hash=sha256:e67d06fe947c36a7ca39f4994b08d73922d40e6cca949907be05efa6fd75110b
+urllib3==2.6.2 \
+    --hash=sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797 \
+    --hash=sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd
     # via
     #   requests
     #   requests-cache


### PR DESCRIPTION
We decided not to do a major version upgrade of our core dependencies without extra testing. This repository is low risk as it is not very complicated, but that still applies.

I accidentally upgraded to Django 6.0 while doing the dependency rota. The site is still alive at https://reports.opensafely.org/ so it doesn't appear to have done much harm, if any. But we should still revert until we're confident.

This also includes a bugfix update to `urllib3`.

Fixes #1045.