### PR TITLE
Add noindex header and a banner to archived reports

### DIFF
--- a/reports/views.py
+++ b/reports/views.py
@@ -64,7 +64,11 @@ def report_view(request, slug):
     `force-update` query parameter.
     """
     try:
-        report = Report.objects.for_user(request.user).get(slug=slug)
+        report = (
+            Report.objects.for_user(request.user)
+            .select_related("category")
+            .get(slug=slug)
+        )
     except Report.DoesNotExist:
         raise Http404("Report matching query does not exist")
 
@@ -80,12 +84,15 @@ def report_view(request, slug):
 
     remote_cls = GithubReport if report.uses_github else JobServerReport
     remote = remote_cls(report)
+    is_archived_report = report.category.name.lower() == "archive"
 
-    return TemplateResponse(
+    response = TemplateResponse(
         request,
         "report.html",
-        {
-            "remote": remote,
-            "report": report,
-        },
+        {"remote": remote, "report": report},
     )
+
+    if is_archived_report:
+        response.headers["X-Robots-Tag"] = "noindex"
+
+    return response

--- a/reports/views.py
+++ b/reports/views.py
@@ -86,7 +86,7 @@ def report_view(request, slug):
 
     remote_cls = GithubReport if report.uses_github else JobServerReport
     remote = remote_cls(report)
-    is_archived_report = report.category.name.lower() == archive_category_name
+    is_archived_report = report.category.name.casefold() == archive_category_name
 
     response = TemplateResponse(
         request,

--- a/reports/views.py
+++ b/reports/views.py
@@ -12,6 +12,8 @@ from .models import Report
 
 logger = structlog.getLogger()
 
+archive_category_name = "archive"
+
 
 @never_cache
 def landing(request):
@@ -20,7 +22,7 @@ def landing(request):
     # back and compared their activity dates we don't know which ones we will be using, so we grab ten of each which
     # must be enough.
     all_reports = Report.objects.for_user(request.user).exclude(
-        category__name__iexact="archive"
+        category__name__iexact=archive_category_name
     )
 
     # To avoid duplication of reports in the activity list, we don't display the publication event for reports that
@@ -84,12 +86,12 @@ def report_view(request, slug):
 
     remote_cls = GithubReport if report.uses_github else JobServerReport
     remote = remote_cls(report)
-    is_archived_report = report.category.name.lower() == "archive"
+    is_archived_report = report.category.name.lower() == archive_category_name
 
     response = TemplateResponse(
         request,
         "report.html",
-        {"remote": remote, "report": report},
+        {"remote": remote, "report": report, "is_archived_report": is_archived_report},
     )
 
     if is_archived_report:

--- a/templates/report.html
+++ b/templates/report.html
@@ -17,6 +17,14 @@
 {% endblock %}
 
 {% block content %}
+  {% if is_archived_report %}
+    <div class="md:container mx-auto mt-6 md:px-8">
+      <div class="rounded-lg bg-indigo-700 text-white text-center font-semibold text-base/snug p-2 shadow-lg sm:p-3">
+        <p>This report has been archived</p>
+      </div>
+    </div>
+  {% endif %}
+
   {% with report_token=report.cache_token %}
     {% cache 86400 report_content report_token %}
       <article class="md:container mx-auto md:px-8">

--- a/tests/reports/test_views.py
+++ b/tests/reports/test_views.py
@@ -339,6 +339,24 @@ def test_report_view_does_not_set_noindex_header_for_non_archive_reports(
 
 
 @pytest.mark.django_db
+def test_archive_banner_is_rendered_for_archive_reports(client, mocker, bennett_org):
+    remote = mocker.Mock()
+    remote.last_updated = date(2021, 1, 1)
+    remote.get_html.return_value = "<h1>Archived report</h1>"
+    mocker.patch("reports.views.GithubReport", return_value=remote)
+
+    report = ReportFactory(
+        category=CategoryFactory(name="Archive"),
+        org=bennett_org,
+    )
+
+    response = client.get(report.get_absolute_url())
+
+    assert response.status_code == 200
+    assert "This report has been archived" in response.rendered_content
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     "user_attributes,is_draft,expected_status",
     [

--- a/tests/reports/test_views.py
+++ b/tests/reports/test_views.py
@@ -1,12 +1,14 @@
 from datetime import date, timedelta
 
 import pytest
+from django.contrib.auth.models import AnonymousUser
 from django.urls import reverse
 
 from gateway.models import User
 from reports.groups import setup_researchers
 from reports.models import Category, Report
 from reports.rendering import process_html
+from reports.views import report_view
 
 from ..factories import CategoryFactory, ReportFactory, UserFactory
 from .utils import assert_html_equal
@@ -268,6 +270,8 @@ def test_report_view(client, bennett_org):
     )
     response = client.get(report.get_absolute_url())
 
+    assert "X-Robots-Tag" not in response.headers
+
     assert_html_equal(
         process_html(response.context["remote"].get_html()),
         """
@@ -300,8 +304,38 @@ def test_archive_report_view(client, bennett_org):
 
     response = client.get(archive_report.get_absolute_url())
     assert response.status_code == 200
+    assert response.headers["X-Robots-Tag"] == "noindex"
     assert response.context["report"] == archive_report
     assert [category.id for category in response.context["categories"]] == [category.id]
+
+
+@pytest.mark.django_db
+def test_report_view_sets_noindex_header_for_archive_reports(rf, bennett_org):
+    report = ReportFactory(
+        category=CategoryFactory(name="Archive"),
+        org=bennett_org,
+    )
+    request = rf.get(report.get_absolute_url())
+    request.user = AnonymousUser()
+
+    response = report_view(request, slug=report.slug)
+
+    assert response.headers["X-Robots-Tag"] == "noindex"
+    assert response.context_data["is_archived_report"] is True
+
+
+@pytest.mark.django_db
+def test_report_view_does_not_set_noindex_header_for_non_archive_reports(
+    rf, bennett_org
+):
+    report = ReportFactory(org=bennett_org)
+    request = rf.get(report.get_absolute_url())
+    request.user = AnonymousUser()
+
+    response = report_view(request, slug=report.slug)
+
+    assert "X-Robots-Tag" not in response.headers
+    assert response.context_data["is_archived_report"] is False
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
As reports in the archived section are still showing up high on Google.

[Slack thread with more info](https://bennettoxford.slack.com/archives/C63UXGB8E/p1775131854476109)

## Example screenshot

This is what the banner on archived reports looks like:

<img width="2788" height="1395" alt="" src="https://github.com/user-attachments/assets/44414cfc-a545-469e-8b59-9ff0df1f0267" />
