### PR TITLE
Pin pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,8 +16,15 @@ repos:
       language: system
       types: [python]
       require_serial: true
+    - id: hadolint
+      name: Hadolint
+      description: Haskell-based Docker image linter
+      language: docker_image
+      types: [dockerfile]
+      entry: hadolint/hadolint:v2.14.0@sha256:27086352fd5e1907ea2b934eb1023f217c5ae087992eb59fde121dce9c9ff21e hadolint
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # v6.0.0
     hooks:
     - id: trailing-whitespace
     - id: end-of-file-fixer
@@ -27,8 +34,3 @@ repos:
     - id: check-toml
     - id: check-yaml
     - id: detect-private-key
-
-  - repo: https://github.com/stratasan/hadolint-pre-commit
-    rev: cdefcb0
-    hooks:
-    - id: hadolint


### PR DESCRIPTION
And remove the hadolint hook.

It was from:

https://github.com/stratasan/hadolint-pre-commit/commit/cdefcb096e520a6daa9552b1d4636f5f1e1729cd

which was simply:

```
- id: hadolint
  name: Hadolint
  description: Haskell-based Docker image linter
  language: docker_image
  types:
  - dockerfile
  entry: --entrypoint /bin/hadolint hadolint/hadolint:latest --ignore DL3013 --ignore DL3018 --ignore DL3008 -
```

This is a local version of the same hook, but without the ignores. The ignores weren't needed, so we should remove them. (And we should really ignore rules in the Dockerfile as we do already.)