### PR TITLE
Replace deprecated `structlog.threadlocal.wrap_dict`

### DIFF
--- a/services/logging.py
+++ b/services/logging.py
@@ -32,6 +32,7 @@ pre_chain = [
 
 structlog.configure(
     processors=[
+        structlog.contextvars.merge_contextvars,
         structlog.stdlib.filter_by_level,
         timestamper,
         structlog.stdlib.add_logger_name,
@@ -43,7 +44,6 @@ structlog.configure(
         structlog.processors.ExceptionPrettyPrinter(),
         structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
     ],
-    context_class=structlog.threadlocal.wrap_dict(dict),
     logger_factory=structlog.stdlib.LoggerFactory(),
     wrapper_class=structlog.stdlib.BoundLogger,
     cache_logger_on_first_use=True,


### PR DESCRIPTION
Replace deprecated `structlog.threadlocal.wrap_dict` context storage with `structlog.contextvars.merge_contextvars`, which is the supported context propagation mechanism for latest structlog versions.
This was deprecated in version `22.1.0` and we are currently on `structlog` version `25.5.0` so its safe to remove.