### PR TITLE
Tweak constraint for Dependabot

### DIFF
--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -1,4 +1,4 @@
---constraint requirements.prod.txt
+-c requirements.prod.in
 
 # Additional dev requirements
 # To generate a requirements file that includes both prod and dev requirements, run:

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -150,7 +150,6 @@ packaging==26.2 \
     --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e \
     --hash=sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661
     # via
-    #   -c requirements.prod.txt
     #   build
     #   pytest
     #   wheel
@@ -162,7 +161,6 @@ platformdirs==4.11.0 \
     --hash=sha256:0555d18370482847566ffabcaa53ad7c6c1c29f195989ae1ed634a05f76ea1e0 \
     --hash=sha256:360ccded2b7fce0af0ff80cc8f5942a1c5d99b0e856033acb030bfc634709e74
     # via
-    #   -c requirements.prod.txt
     #   python-discovery
     #   virtualenv
 pluggy==1.6.0 \
@@ -218,9 +216,7 @@ python-discovery==1.5.0 \
 python-dotenv==1.2.2 \
     --hash=sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a \
     --hash=sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3
-    # via
-    #   -c requirements.prod.txt
-    #   pytest-env
+    # via pytest-env
 pyyaml==6.0.3 \
     --hash=sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c \
     --hash=sha256:0150219816b6a1fa26fb4699fb7daa9caf09eb1999f3b70fb6e786805e80375a \
@@ -319,9 +315,7 @@ ruff==0.16.0 \
 six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
-    # via
-    #   -c requirements.prod.txt
-    #   python-dateutil
+    # via python-dateutil
 virtualenv==21.7.0 \
     --hash=sha256:7f9519b9432ff11b6e1a3e94061664efc2ff99ea21780e3cf4f6bd0a5da8b37c \
     --hash=sha256:a8370c1c5530fbabf955e40b8fbbc68a431648b10f9433faa587db30a06e51dd


### PR DESCRIPTION
Dependabot graph resolution is working on [opensafely-core/actions-registry](https://github.com/opensafely-core/actions-registry/blob/5a58750b0f4137800163f3642225572faebc84a6/requirements.dev.in#L1) and this is the only difference I can see between the two repos, the one that works, and this repo that doesn't.